### PR TITLE
Improve API feedback

### DIFF
--- a/app/data/form-api.ts
+++ b/app/data/form-api.ts
@@ -37,8 +37,11 @@ export const useDeleteForm = () => {
     if (res?.ok) {
       client.invalidateQueries({ queryKey: ['forms'] });
     } else {
-      toast.error(`Failed to remove from '${identifier.id}'`, { description: 'Maybe the server is not correclty started' });
+      throw new Error(`Failed to remove from '${identifier.id}'`);
     }
   };
-  return { deleteForm };
+  return {
+    deleteForm: (identifier: FormIdentifier) =>
+      toast.promise(() => deleteForm(identifier), { loading: 'Remove form', success: 'From removed', error: e => e.message })
+  };
 };

--- a/app/data/process-api.ts
+++ b/app/data/process-api.ts
@@ -49,10 +49,13 @@ export const useCreateProcess = () => {
       // FIXME hardcode app and pmv for now. Must be queried form the backend in the end
       openEditor(editorOfPath('processes', 'designer', 'workflow-demos', `${process.namespace}/${process.name}`));
     } else {
-      toast.error('Failed to add new process', { description: 'Maybe the server is not correclty started' });
+      throw new Error('Failed to create process');
     }
   };
-  return { createProcess };
+  return {
+    createProcess: (process: NewProcessParams) =>
+      toast.promise(() => createProcess(process), { loading: 'Creating process', success: 'Process created', error: e => e.message })
+  };
 };
 
 export const useDeleteProcess = () => {
@@ -62,8 +65,11 @@ export const useDeleteProcess = () => {
     if (res?.ok) {
       client.invalidateQueries({ queryKey: ['processes'] });
     } else {
-      toast.error(`Failed to remove process '${identifier.pid}'`, { description: 'Maybe the server is not correclty started' });
+      throw new Error(`Failed to remove process '${identifier.pid}'`);
     }
   };
-  return { deleteProcess };
+  return {
+    deleteProcess: (identifier: ProcessIdentifier) =>
+      toast.promise(() => deleteProcess(identifier), { loading: 'Remove process', success: 'Process removed', error: e => e.message })
+  };
 };


### PR DESCRIPTION
- Show spinner while try create/delete from/process
- Show success toast if ok
- Show error toast if not ok

![Screen Recording 2024-06-17 at 10 40 09](https://github.com/axonivy/neo/assets/42733123/eeb40ae1-5865-49ee-820c-b4fdfa25d685)


Currently the create process API returns only the absolute path as text (which is ok for vscode I think), but I think it should return a ProcessBean (the same as for the processes list). maybe we can control what should be returned by a request header?