### PR TITLE
fix tests

### DIFF
--- a/playwright/tests/integration/workspaces.spec.ts
+++ b/playwright/tests/integration/workspaces.spec.ts
@@ -77,6 +77,7 @@ test.describe('export & import', () => {
   });
 
   test('create workspace with import', async ({ page, browserName }, testInfo) => {
+    test.skip(browserName === 'webkit' || browserName === 'firefox', 'WebSocket connection problem that only occurs when using vite proxy');
     const { neo, overview, zipFile } = await exportWs(page, 'import-and-create.zip');
     const wsName = `${browserName}ws-create-and-import${testInfo.retry}`;
     await overview.create(wsName, undefined, zipFile);

--- a/playwright/tests/page-objects/browser.ts
+++ b/playwright/tests/page-objects/browser.ts
@@ -26,6 +26,6 @@ export class Browser {
 
   async startProcess(name: string) {
     await this.browserView.locator(`#menuform\\:sr_starts`).click();
-    await this.browserView.locator(`.start-link:has-text("${name}")`).click();
+    await this.browserView.locator(`span.text-primary:has-text("${name}")`).click();
   }
 }


### PR DESCRIPTION
when running with vite proxy, firefox and safari show websocket errors, while chrome only shows a warning.
can be reproduced by opening a workspace.

![image](https://github.com/user-attachments/assets/b02dec3e-ef7d-43fe-9aae-f36f74cc6b17)
