### PR TITLE
XIVY-12289 data class editor inscription test

### DIFF
--- a/playwright/global.teardown.ts
+++ b/playwright/global.teardown.ts
@@ -1,0 +1,7 @@
+import { rm } from 'node:fs';
+
+const teardown = async () => {
+  rm('./neo-test-project/dataclasses/temp', { force: true, recursive: true }, () => {});
+};
+
+export default teardown;

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     url: 'http://localhost:5173/neo/',
     reuseExistingServer: !process.env.CI
   },
+  globalTeardown: './global.teardown',
   projects: [
     { name: 'integration-chrome', use: { ...devices['Desktop Chrome'] }, testDir: './tests/integration' },
     { name: 'integration-firefox', use: { ...devices['Desktop Firefox'] }, testDir: './tests/integration' },

--- a/playwright/tests/integration/data-classes.spec.ts
+++ b/playwright/tests/integration/data-classes.spec.ts
@@ -1,30 +1,51 @@
 import { expect, test } from '@playwright/test';
+import { randomUUID } from 'crypto';
 import { DataClassEditor } from '../page-objects/data-class-editor';
 import { Neo } from '../page-objects/neo';
+import { Overview } from '../page-objects/overview';
 
-test('navigate to data classes', async ({ page }) => {
+let neo: Neo;
+let overview: Overview;
+
+test.beforeEach(async ({ page }) => {
+  neo = await Neo.openWorkspace(page);
+  overview = await neo.dataClasses();
+});
+
+test('navigate to data classes', async () => {
   const dataClassName = 'QuickStartTutorial';
-  const neo = await Neo.openWorkspace(page);
-  const overview = await neo.dataClasses();
   await overview.card(dataClassName).click();
   await new DataClassEditor(neo, dataClassName).waitForOpen('releaseDate');
 });
 
-test('create and delete data class', async ({ page, browserName }, testInfo) => {
-  const dataClassName = `${browserName}dataClass${testInfo.retry}`;
-  const neo = await Neo.openWorkspace(page);
-  const overview = await neo.dataClasses();
-  await overview.create(dataClassName, 'hello.test');
+test('create and delete data class', async () => {
+  const dataClassName = `dataClass${randomUUID().replaceAll('-', '')}`;
+  await overview.create(dataClassName, 'temp', { project: 'neo-test-project' });
   await new DataClassEditor(neo, dataClassName).waitForOpen();
-  await page.goBack();
+  await neo.page.goBack();
   await overview.deleteCard(dataClassName);
+  await expect(overview.card(dataClassName)).toBeHidden();
 });
 
-test('search data classes', async ({ page }) => {
-  const neo = await Neo.openWorkspace(page);
-  const overview = await neo.dataClasses();
+test('search data classes', async () => {
   await overview.search.fill('bla');
   await expect(overview.cards).toHaveCount(0);
   await overview.search.fill('quick');
   await expect(overview.cards).toHaveCount(1);
+});
+
+test.describe('inscription', async () => {
+  test('add and delete field', async () => {
+    const dataClassName = `dataClass${randomUUID().replaceAll('-', '')}`;
+    await overview.create(dataClassName, 'temp', { project: 'neo-test-project' });
+
+    const editor = new DataClassEditor(neo, dataClassName);
+    await editor.waitForOpen();
+
+    await expect(editor.rows).toHaveCount(0);
+    await editor.addField();
+    await expect(editor.rows).toHaveCount(1);
+    await editor.deleteField();
+    await expect(editor.rows).toHaveCount(0);
+  });
 });

--- a/playwright/tests/integration/workspaces.spec.ts
+++ b/playwright/tests/integration/workspaces.spec.ts
@@ -91,7 +91,7 @@ test.describe('export & import', () => {
     test.skip(browserName === 'webkit' || browserName === 'firefox', 'WebSocket connection problem that only occurs when using vite proxy');
     const { neo, overview, zipFile } = await exportWs(page, 'import-and-create.zip');
     const wsName = `${browserName}ws-create-and-import${testInfo.retry}`;
-    await overview.create(wsName, undefined, zipFile);
+    await overview.create(wsName, undefined, { file: zipFile });
 
     await expect(page.locator(`text=Welcome to your workspace: ${wsName}`)).toBeVisible();
 

--- a/playwright/tests/page-objects/data-class-editor.ts
+++ b/playwright/tests/page-objects/data-class-editor.ts
@@ -3,24 +3,35 @@ import { Neo } from './neo';
 
 export class DataClassEditor {
   readonly editor: Locator;
+  readonly rows: Locator;
 
   constructor(
     readonly neo: Neo,
     readonly name: string
   ) {
     this.editor = neo.page.locator(`.data-class-editor[data-editor-name="${name}"]`);
+    this.rows = this.editor.locator('tbody tr');
   }
 
-  async waitForOpen(variable?: string) {
+  async waitForOpen(dataClass?: string) {
     await this.neo.controlBar.tab(this.name).expectActive();
     await expect(this.editor).toBeVisible();
-    if (variable) {
-      await expect(this.rowByName(variable).row).toBeVisible();
+    if (dataClass) {
+      await expect(this.rowByName(dataClass).row).toBeVisible();
     }
   }
 
   rowByName(name: string) {
     return new DataClassEditorRow(this, name);
+  }
+
+  async addField() {
+    await this.editor.getByRole('button', { name: 'Add field' }).click();
+    await this.neo.page.getByRole('button', { name: 'Create field' }).click();
+  }
+
+  async deleteField() {
+    await this.editor.getByRole('button', { name: 'Delete field' }).click();
   }
 }
 

--- a/playwright/tests/page-objects/overview.ts
+++ b/playwright/tests/page-objects/overview.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page } from '@playwright/test';
+import { app } from '../integration/app';
 
 export class Overview {
   protected readonly page: Page;
@@ -55,12 +56,17 @@ export class Overview {
     await fileChooser.setFiles(file);
   }
 
+  private async selectProject(dialog: Locator, project: string) {
+    await dialog.getByRole('combobox', { name: 'Project' }).click();
+    await this.page.getByRole('option', { name: `${app}/${project}` }).click();
+  }
+
   async clickCardAction(card: Locator, actionName: string) {
     await card.locator('.card-menu-trigger').click();
     await this.page.getByRole('menu').getByRole('menuitem', { name: actionName }).click();
   }
 
-  async create(name: string, namespace?: string, file?: string) {
+  async create(name: string, namespace?: string, options?: { file?: string; project?: string }) {
     await this.waitForHiddenSpinner();
     const createCard = this.overview.locator('.new-artifact-card');
     await expect(createCard).toBeVisible();
@@ -71,8 +77,11 @@ export class Overview {
     if (namespace) {
       await dialog.getByLabel('Namespace').first().fill(namespace);
     }
-    if (file) {
-      await this.selectImport(dialog, file);
+    if (options?.file) {
+      await this.selectImport(dialog, options.file);
+    }
+    if (options?.project) {
+      await this.selectProject(dialog, options.project);
     }
     await dialog.getByRole('button', { name: 'Create' }).click();
   }


### PR DESCRIPTION
Simple test of making some changes in the data class editor.

Also made some improvements for test stability:
- allow to create new data classes in the correct app for testing
- delete `neo-test-project/dataclasses/temp` directory after running tests