### PR TITLE
Update to v12 one pom manually

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>ch.ivyteam.neo</groupId>
   <artifactId>neo-designer</artifactId>
-  <version>11.4.0-SNAPSHOT</version>
+  <version>12.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <distributionManagement>


### PR DESCRIPTION
Hi @ivy-lli @ivy-lmu 
This pom hasn't been updated with update-version.
And maybe there also packages in packages.json which still points to 11.4.0 (not sure if this is correct).
Maybe someone of you can fix the update version and have a quick look into packages.json

thanks!