### PR TITLE
XIVY-15587 encode path part of editor id

### DIFF
--- a/app/neo/editors/useCreateEditor.tsx
+++ b/app/neo/editors/useCreateEditor.tsx
@@ -39,7 +39,8 @@ export const useCreateEditor = () => {
 
 const createEditor = (ws: string, editorType: EditorType, project: ProjectIdentifier, path: string, name: string): Editor => {
   const routeEditorType = editorType === 'variables' ? 'configurations' : editorType;
-  const id = `/${ws}/${routeEditorType}/${project.app}/${project.pmv}/${path}`;
+  const encodedPath = encodeURI(path);
+  const id = `/${ws}/${routeEditorType}/${project.app}/${project.pmv}/${encodedPath}`;
   return {
     id: removeExtension(id),
     type: editorType,


### PR DESCRIPTION
problem:
spaces are valid for process groups, e.g. `processes/AI Tool Processes/PortalCallableTools`. we use the process path as part of the route, which is then encoded by the browser resulting in `processes/AI%20Tool%20Processes/PortalCallableTools`. no editor can be resolved for the encoded path.