### PR TITLE
XIVY-15008 market: allow snapshots & use best matching version

### DIFF
--- a/app/data/engine-info-api.ts
+++ b/app/data/engine-info-api.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { ok } from './custom-fetch';
+import { getInfo } from './generated/openapi-default';
+
+export const useEngineInfoApi = () => {
+  return { queryKey: ['neo', 'engine-info'] };
+};
+
+export const useEngineVersion = () => {
+  const { queryKey } = useEngineInfoApi();
+  return useQuery({
+    queryKey,
+    queryFn: () =>
+      getInfo().then(res => {
+        const version = res.data.version;
+        if (ok(res) && version) {
+          return version.substring(0, version.lastIndexOf('.'));
+        }
+        throw new Error('Failed to load engine version');
+      })
+  });
+};

--- a/app/data/generated/openapi-default.ts
+++ b/app/data/generated/openapi-default.ts
@@ -189,6 +189,26 @@ export interface WebNotificationOperation {
   operation?: WebNotificationOperationOperation;
 }
 
+/**
+ * Returns the version and the name of the engine
+ */
+export type getInfoResponse = {
+  data: EngineInfo;
+  status: number;
+  headers: Headers;
+};
+
+export const getGetInfoUrl = () => {
+  return `/engine/info`;
+};
+
+export const getInfo = async (options?: RequestInit): Promise<getInfoResponse> => {
+  return customFetch<Promise<getInfoResponse>>(getGetInfoUrl(), {
+    ...options,
+    method: 'GET'
+  });
+};
+
 export type workspacesResponse = {
   data: WorkspaceBean[];
   status: number;

--- a/app/data/generated/openapi-dev.ts
+++ b/app/data/generated/openapi-dev.ts
@@ -261,6 +261,26 @@ export interface WebNotificationOperation {
   operation?: WebNotificationOperationOperation;
 }
 
+/**
+ * Returns the version and the name of the engine
+ */
+export type getInfoResponse = {
+  data: EngineInfo;
+  status: number;
+  headers: Headers;
+};
+
+export const getGetInfoUrl = () => {
+  return `/engine/info`;
+};
+
+export const getInfo = async (options?: RequestInit): Promise<getInfoResponse> => {
+  return customFetch<Promise<getInfoResponse>>(getGetInfoUrl(), {
+    ...options,
+    method: 'GET'
+  });
+};
+
 export type configurationsResponse = {
   data: ConfigurationIdentifier[];
   status: number;

--- a/orval.config.ts
+++ b/orval.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'orval';
 
 const hooks = { afterAllFilesWrite: 'prettier --write' };
-const filters = { tags: ['web-ide'], schemas: [/.*/] };
+const filters = { tags: ['web-ide', 'engine'], schemas: [/.*/] };
 const client = 'fetch';
 const override = {
   mutator: {


### PR DESCRIPTION
by default, the best matching version is selected, which depends on the engine version, in this case 11.1.1.  snapshots can now also be installed:
<img width="855" alt="image" src="https://github.com/user-attachments/assets/fa097632-c92b-45a9-a0e0-e11332f550d7" />
