### PR TITLE
switch from designer to engine url

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm i
 
 ## Development
 
-Start an Axon Ivy Designer (on port 8081) and run:
+Start an Axon Ivy Engine (on port 8080) and run:
 
 ```shellscript
 npm run dev

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,13 +3,13 @@ import { type ProxyOptions, defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-const DESIGNER_URL = process.env.BASE_URL ?? 'http://localhost:8081/';
+const ENGINE_URL = process.env.BASE_URL ?? 'http://localhost:8080/';
 const WEBSOCKET_PROXY: ProxyOptions = {
-  target: DESIGNER_URL,
+  target: ENGINE_URL,
   ws: true
 };
 const DEV_PROXY: ProxyOptions = {
-  target: DESIGNER_URL,
+  target: ENGINE_URL,
   followRedirects: true
 };
 
@@ -19,11 +19,11 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: DESIGNER_URL,
+        target: ENGINE_URL,
         auth: 'Developer:Developer'
       },
       '^/~.*': {
-        target: DESIGNER_URL,
+        target: ENGINE_URL,
         auth: 'Developer:Developer',
         ws: true
       },

--- a/webviews/process-editor/src/url-helper.ts
+++ b/webviews/process-editor/src/url-helper.ts
@@ -4,7 +4,7 @@ export function getServerDomain(): string {
     const href = window.location.href;
     return href.substring(protocol.length + 2, href.indexOf('/neo/process-editor'));
   }
-  return 'localhost:8081';
+  return 'localhost:8080';
 }
 
 export function isSecureConnection(): boolean {


### PR DESCRIPTION
I don't use designer as endpoint and I don't recommend it anymore because several endpoints are not supported with designer.