### PR TITLE
XIVY-15633 Add hotkeys to neo

### DIFF
--- a/app/neo/Navigation.tsx
+++ b/app/neo/Navigation.tsx
@@ -1,12 +1,41 @@
-import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuSeparator, DropdownMenuTrigger, Flex } from '@axonivy/ui-components';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Flex,
+  useHotkeys
+} from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
-import { NavLink } from 'react-router';
+import { useRef } from 'react';
+import { NavLink, useNavigate } from 'react-router';
+import { useKnownHotkeys } from '~/utils/hotkeys';
 import { useNeoClient } from './client/useNeoClient';
 import { AnimationSettingsMenu } from './settings/AnimationSettingsMenu';
-import { ThemeSettings } from './settings/ThemeSettings';
+import { ThemeSettings, useCycleTheme } from './settings/ThemeSettings';
+import { useCycleAnimationSettings } from './settings/useSettings';
 
 export const Navigation = () => {
   useNeoClient();
+  const { cycleAnimationMode, cycleAnimationSpeed, toggleAnimation } = useCycleAnimationSettings();
+  const navigate = useNavigate();
+  const cycleTheme = useCycleTheme();
+
+  const hotkeys = useKnownHotkeys();
+  const workspacesElement = useRef<HTMLButtonElement>(null);
+
+  useHotkeys(hotkeys.focusNav.hotkey, () => workspacesElement.current?.focus(), { enableOnFormTags: true });
+  useHotkeys(hotkeys.openWorkspaces.hotkey, () => navigate(''), { enableOnFormTags: true });
+  useHotkeys(hotkeys.openProcesses.hotkey, () => navigate('Processes'), { enableOnFormTags: true });
+  useHotkeys(hotkeys.openForms.hotkey, () => navigate('Forms'), { enableOnFormTags: true });
+  useHotkeys(hotkeys.openDataClasses.hotkey, () => navigate('Dataclasses'), { enableOnFormTags: true });
+  useHotkeys(hotkeys.openConfigs.hotkey, () => navigate('Configurations'), { enableOnFormTags: true });
+  useHotkeys(hotkeys.changeTheme.hotkey, cycleTheme);
+  useHotkeys(hotkeys.toggleAnimation.hotkey, toggleAnimation);
+  useHotkeys(hotkeys.animationSpeed.hotkey, cycleAnimationSpeed);
+  useHotkeys(hotkeys.animationMode.hotkey, cycleAnimationMode);
+
   return (
     <Flex
       direction='column'
@@ -16,19 +45,55 @@ export const Navigation = () => {
       role='navigation'
     >
       <Flex direction='column' gap={4}>
-        <NavLink to='' prefetch='intent' style={{ all: 'unset' }} aria-label='Workspace' title='Workspace' end>
-          {({ isActive }) => <Button icon={IvyIcons.Home} size='large' toggle={isActive} />}
+        <NavLink
+          to=''
+          prefetch='intent'
+          style={{ all: 'unset' }}
+          aria-label={hotkeys.openWorkspaces.label}
+          title={hotkeys.openWorkspaces.label}
+          tabIndex={-1}
+          end
+        >
+          {({ isActive }) => <Button icon={IvyIcons.Home} size='large' toggle={isActive} ref={workspacesElement} />}
         </NavLink>
-        <NavLink to='processes' prefetch='intent' style={{ all: 'unset' }} aria-label='Processes' title='Processes'>
+        <NavLink
+          to='processes'
+          prefetch='intent'
+          style={{ all: 'unset' }}
+          aria-label={hotkeys.openProcesses.label}
+          title={hotkeys.openProcesses.label}
+          tabIndex={-1}
+        >
           {({ isActive }) => <Button icon={IvyIcons.Process} size='large' toggle={isActive} />}
         </NavLink>
-        <NavLink to='dataclasses' prefetch='intent' style={{ all: 'unset' }} aria-label='Data Classes' title='Data Classes'>
+        <NavLink
+          to='dataclasses'
+          prefetch='intent'
+          style={{ all: 'unset' }}
+          aria-label={hotkeys.openDataClasses.label}
+          title={hotkeys.openDataClasses.label}
+          tabIndex={-1}
+        >
           {({ isActive }) => <Button icon={IvyIcons.Database} size='large' toggle={isActive} />}
         </NavLink>
-        <NavLink to='forms' prefetch='intent' style={{ all: 'unset' }} aria-label='Forms' title='Forms'>
+        <NavLink
+          to='forms'
+          prefetch='intent'
+          style={{ all: 'unset' }}
+          aria-label={hotkeys.openForms.label}
+          title={hotkeys.openForms.label}
+          tabIndex={-1}
+        >
           {({ isActive }) => <Button icon={IvyIcons.File} size='large' toggle={isActive} />}
         </NavLink>
-        <NavLink to='configurations' prefetch='intent' style={{ all: 'unset' }} aria-label='Configurations' title='Configurations'>
+        <NavLink
+          to='configurations'
+          prefetch='intent'
+          style={{ all: 'unset' }}
+          aria-label={hotkeys.openConfigs.label}
+          title={hotkeys.openConfigs.label}
+          tabIndex={-1}
+        >
           {({ isActive }) => <Button icon={IvyIcons.Tool} size='large' toggle={isActive} />}
         </NavLink>
       </Flex>

--- a/app/neo/Overview.tsx
+++ b/app/neo/Overview.tsx
@@ -1,6 +1,7 @@
+/* eslint-disable jsx-a11y/no-autofocus */
 import { Button, Flex, SearchInput, Spinner } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
-import type { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { InfoPopover } from './InfoPopover';
 
 type OverviewProps = {
@@ -29,7 +30,7 @@ export const Overview = ({ title, description, search, onSearchChange, isPending
         {helpUrl && <HelpButton url={helpUrl} />}
       </Flex>
     )}
-    <SearchInput placeholder='Search' value={search} onChange={onSearchChange} />
+    <SearchInput placeholder='Search' value={search} onChange={onSearchChange} autoFocus={true} />
     <Flex gap={4} style={{ flexWrap: 'wrap' }}>
       {isPending ? <Spinner size='small' className='overview-loader' /> : <>{children}</>}
     </Flex>

--- a/app/neo/artifact/ArifactInfoCard.css
+++ b/app/neo/artifact/ArifactInfoCard.css
@@ -1,0 +1,30 @@
+.artifact-info-card {
+  background: var(--N50);
+  padding: 24px;
+  border-radius: 10px;
+  font-size: 14px;
+  flex: 1 0 300px;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  transition: box-shadow 0.3s ease;
+  .artifact-icon {
+    font-size: 35px;
+    color: var(--P75);
+  }
+  .artifact-title {
+    font-weight: 600;
+  }
+  .artifact-description {
+    color: var(--N500);
+  }
+  .artifact-footer {
+    font-weight: 500;
+    align-self: flex-end;
+    color: var(--P300);
+  }
+}
+
+.artifact-info-card:hover {
+  box-shadow: var(--focus-shadow);
+}

--- a/app/neo/artifact/ArtifactInfoCard.tsx
+++ b/app/neo/artifact/ArtifactInfoCard.tsx
@@ -1,6 +1,7 @@
 import { Flex, IvyIcon } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useNavigate } from 'react-router';
+import './ArifactInfoCard.css';
 
 type ArtifactInfoCardProps = {
   title: string;
@@ -13,25 +14,12 @@ export const ArtifactInfoCard = ({ title, description, icon, link }: ArtifactInf
   const naviagte = useNavigate();
   const open = () => naviagte(link);
   return (
-    <button
-      className='artifact-info-card'
-      onClick={open}
-      style={{
-        background: 'var(--N50)',
-        padding: 24,
-        borderRadius: 10,
-        fontSize: 14,
-        flex: '1 0 300px',
-        border: 'none',
-        textAlign: 'left',
-        cursor: 'pointer'
-      }}
-    >
+    <button className='artifact-info-card' onClick={open}>
       <Flex direction='column' gap={3}>
-        <IvyIcon icon={icon} style={{ fontSize: 35, color: 'var(--P75)' }} />
-        <span style={{ fontWeight: 600 }}>{title}</span>
+        <IvyIcon icon={icon} className='artifact-icon' />
+        <span className='artifact-title'>{title}</span>
         <span>{description}</span>
-        <Flex alignItems='center' gap={1} style={{ fontWeight: 500, alignSelf: 'flex-end', color: 'var(--P300)' }}>
+        <Flex alignItems='center' gap={1} className='artifact-footer'>
           Open <IvyIcon icon={IvyIcons.Chevron} />
         </Flex>
       </Flex>

--- a/app/neo/artifact/DeleteConfirm.tsx
+++ b/app/neo/artifact/DeleteConfirm.tsx
@@ -1,12 +1,20 @@
-import { Button, Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@axonivy/ui-components';
+import { Button, Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
-import type { ReactNode } from 'react';
 
 export type DeleteAction = { run: () => void; isDeletable: boolean; message?: string; label?: string };
 
-export const DeleteConfirm = ({ children, title, deleteAction }: { children: ReactNode; title: string; deleteAction: DeleteAction }) => (
-  <Dialog>
-    <DialogTrigger asChild>{children}</DialogTrigger>
+export const DeleteConfirm = ({
+  open,
+  onOpenChange,
+  title,
+  deleteAction
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  deleteAction: DeleteAction;
+}) => (
+  <Dialog open={open} onOpenChange={onOpenChange}>
     <DialogContent>
       <DialogHeader>
         <DialogTitle>{deleteAction.isDeletable ? `Are you sure you want to delete this ${title}?` : deleteAction.message}</DialogTitle>

--- a/app/neo/artifact/card.css
+++ b/app/neo/artifact/card.css
@@ -33,6 +33,9 @@
       max-width: calc(200px - var(--size-1) - 20px);
     }
   }
+  .normal-card:hover {
+    background-color: var(--N200);
+  }
   .card-menu-trigger {
     position: absolute;
     bottom: var(--size-1);
@@ -43,6 +46,10 @@
 .new-artifact-card {
   background: var(--P50);
   color: var(--P300);
+}
+
+.new-artifact-card:hover {
+  background: var(--P75);
 }
 
 .card-menu .card-delete {

--- a/app/neo/browser/WebBrowser.tsx
+++ b/app/neo/browser/WebBrowser.tsx
@@ -2,6 +2,7 @@ import { Button, Flex } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import type { RefObject } from 'react';
 import { useUpdateTheme } from '~/theme/useUpdateTheme';
+import { useHotkeyDispatcher } from '~/utils/hotkeys';
 import { useWebBrowser } from './useWebBrowser';
 
 const updateFrameTheme = (frame: RefObject<HTMLIFrameElement | null>, theme: string) => {
@@ -13,9 +14,13 @@ const updateFrameTheme = (frame: RefObject<HTMLIFrameElement | null>, theme: str
   }
 };
 
-export const WebBrowser = () => {
-  const { nav, homeUrl } = useWebBrowser();
+export const WebBrowser = ({ firstWebbrowserElement }: { firstWebbrowserElement?: React.Ref<HTMLButtonElement> }) => {
+  const { nav, homeUrl, browser } = useWebBrowser();
   useUpdateTheme(nav.frameRef, updateFrameTheme);
+  useHotkeyDispatcher(nav.frameRef);
+
+  const tabIndex = browser.openState ? 0 : -1;
+
   return (
     <Flex direction='column' gap={1} style={{ height: '100%' }}>
       <Flex
@@ -27,11 +32,25 @@ export const WebBrowser = () => {
       >
         Process Simulate
         <Flex alignItems='center' gap={1}>
-          <Button icon={IvyIcons.ArrowRight} rotate={180} title='Back' onClick={nav.back} />
-          <Button icon={IvyIcons.ArrowRight} title='Forward' onClick={nav.forward} />
-          <Button icon={IvyIcons.Redo} title='Reload' onClick={nav.reload} />
-          <Button icon={IvyIcons.Home} title='Home' onClick={nav.home} />
-          <Button icon={IvyIcons.ExitEnd} title='Open in new tab' onClick={nav.openExternal} />
+          <Button
+            icon={IvyIcons.ArrowRight}
+            rotate={180}
+            title='Back'
+            onClick={nav.back}
+            aria-label='Go Back'
+            ref={firstWebbrowserElement}
+            tabIndex={tabIndex}
+          />
+          <Button icon={IvyIcons.ArrowRight} title='Forward' onClick={nav.forward} aria-label='Go Forward' tabIndex={tabIndex} />
+          <Button icon={IvyIcons.Redo} title='Reload' onClick={nav.reload} aria-label='Reload Page' tabIndex={tabIndex} />
+          <Button icon={IvyIcons.Home} title='Home' onClick={nav.home} aria-label='Go to Home' tabIndex={tabIndex} />
+          <Button
+            icon={IvyIcons.ExitEnd}
+            title='Open in new tab'
+            onClick={nav.openExternal}
+            aria-label='Open in New Tab'
+            tabIndex={tabIndex}
+          />
         </Flex>
       </Flex>
       <iframe
@@ -40,6 +59,7 @@ export const WebBrowser = () => {
         title='Dev Browser'
         style={{ width: '100%', height: '100%', border: 'none' }}
         loading='lazy'
+        tabIndex={tabIndex}
       />
     </Flex>
   );

--- a/app/neo/control-bar/ControlBar.tsx
+++ b/app/neo/control-bar/ControlBar.tsx
@@ -1,17 +1,24 @@
-import { Button, Flex } from '@axonivy/ui-components';
-import { Link } from 'react-router';
-import type { ReactNode } from 'react';
+import { Button, Flex, useHotkeys } from '@axonivy/ui-components';
+import { type ReactNode } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { useKnownHotkeys } from '~/utils/hotkeys';
 import IvyLogoSVG from '../axonivy.svg?react';
 
-export const ControlBar = ({ children }: { children?: ReactNode }) => (
-  <Flex style={{ height: '40px', borderBottom: 'var(--basic-border)', background: 'var(--N50)' }} className='control-bar'>
-    <Flex alignItems='center' gap={4} style={{ paddingInline: 'var(--size-3)', borderInlineEnd: 'var(--basic-border)' }}>
-      <Link to='/' prefetch='intent' style={{ all: 'unset' }} aria-label='NEO Home' title='NEO Home'>
-        <Button size='large' style={{ aspectRatio: 1, padding: 0 }}>
-          <IvyLogoSVG />
-        </Button>
-      </Link>
+export const ControlBar = ({ children }: { children?: ReactNode }) => {
+  const navigate = useNavigate();
+  const { openHome } = useKnownHotkeys();
+  useHotkeys(openHome.hotkey, () => navigate('/'));
+
+  return (
+    <Flex style={{ height: '40px', borderBottom: 'var(--basic-border)', background: 'var(--N50)' }} className='control-bar'>
+      <Flex alignItems='center' gap={4} style={{ paddingInline: 'var(--size-3)', borderInlineEnd: 'var(--basic-border)' }}>
+        <Link to='/' prefetch='intent' style={{ all: 'unset' }} aria-label='NEO Home' title='NEO Home'>
+          <Button size='large' style={{ aspectRatio: 1, padding: 0 }} title={openHome.label} aria-label={openHome.label}>
+            <IvyLogoSVG />
+          </Button>
+        </Link>
+      </Flex>
+      {children}
     </Flex>
-    {children}
-  </Flex>
-);
+  );
+};

--- a/app/neo/control-bar/EditorControl.tsx
+++ b/app/neo/control-bar/EditorControl.tsx
@@ -1,11 +1,16 @@
-import { Button, Flex, Popover, PopoverContent, PopoverTrigger } from '@axonivy/ui-components';
+import { Button, Flex, Popover, PopoverContent, PopoverTrigger, useHotkeys } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useState } from 'react';
+import { useKnownHotkeys } from '~/utils/hotkeys';
 import { useEditors } from '../editors/useEditors';
 
 export const EditorsControl = () => {
   const [subMenu, setSubMenu] = useState(false);
   const { editors, closeAllEditors } = useEditors();
+
+  const { closeAllTabs } = useKnownHotkeys();
+  useHotkeys(closeAllTabs.hotkey, () => closeAllEditors());
+
   if (editors.length === 0) {
     return null;
   }
@@ -22,6 +27,8 @@ export const EditorsControl = () => {
               closeAllEditors();
               setSubMenu(false);
             }}
+            aria-label={closeAllTabs.label}
+            title={closeAllTabs.label}
           >
             Close all
           </Button>

--- a/app/neo/control-bar/EditorTabs.tsx
+++ b/app/neo/control-bar/EditorTabs.tsx
@@ -1,7 +1,8 @@
-import { Button, Flex, IvyIcon, Tabs, TabsList, TabsTrigger } from '@axonivy/ui-components';
+import { Button, Flex, IvyIcon, Tabs, TabsList, TabsTrigger, useHotkeys } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
-import { useLocation, useNavigate } from 'react-router';
 import { useEffect, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import { useKnownHotkeys } from '~/utils/hotkeys';
 import { lastSegment } from '~/utils/path';
 import type { Editor } from '../editors/editor';
 import { useEditors } from '../editors/useEditors';
@@ -10,11 +11,16 @@ import { useGroupedEditors } from './useGroupedEditors';
 
 export const EditorTabs = () => {
   const scroller = useRef<HTMLDivElement>(null);
+  const firstTabRef = useRef<HTMLButtonElement>(null);
   const [tab, setTab] = useState('');
   const { pathname } = useLocation();
+
   useEffect(() => setTab(pathname), [pathname]);
   const groupedEditors = useGroupedEditors();
   const navigate = useNavigate();
+  const { focusTabs } = useKnownHotkeys();
+  useHotkeys(focusTabs.hotkey, () => firstTabRef.current?.focus(), { enableOnFormTags: true });
+
   return (
     <Tabs
       ref={scroller}
@@ -28,22 +34,41 @@ export const EditorTabs = () => {
       }}
     >
       <TabsList>
-        {Object.entries(groupedEditors).map(([group, editors]) => (
-          <EditorsTab key={group} group={group} editors={editors} />
+        {Object.entries(groupedEditors).map(([group, editors], index) => (
+          <EditorsTab key={group} group={group} editors={editors} firstTabRef={index === 0 ? firstTabRef : undefined} />
         ))}
       </TabsList>
     </Tabs>
   );
 };
 
-const EditorsTab = ({ group, editors }: { group: string; editors: Array<Editor> }) => {
+const EditorsTab = ({
+  group,
+  editors,
+  firstTabRef
+}: {
+  group: string;
+  editors: Array<Editor>;
+  firstTabRef?: React.RefObject<HTMLButtonElement | null>;
+}) => {
+  const { pathname } = useLocation();
+  const { closeEditors } = useEditors();
+
+  const { closeActiveTabs } = useKnownHotkeys();
+  useHotkeys(closeActiveTabs.hotkey, () => {
+    if (pathname.endsWith(group)) {
+      closeEditors(editors.map(e => e.id));
+    }
+  });
+
   if (editors.length === 0) {
     return null;
   }
   const name = editors.length > 1 ? lastSegment(group) : editors[0].name;
+
   return (
     <Flex className='editor-tab-wrapper' alignItems='center' gap={1}>
-      <TabsTrigger value={editors[0].id} title={editors[0].path} className='editor-tab' aria-label={name}>
+      <TabsTrigger value={editors[0].id} title={editors[0].path} className='editor-tab' aria-label={name} ref={firstTabRef}>
         <IvyIcon className='editor-tab-icon' icon={editors[0].icon} />
         {name}
       </TabsTrigger>
@@ -63,6 +88,7 @@ const EditorSubTab = ({ icon, path, id, name }: Pick<Editor, 'icon' | 'path' | '
 
 const EditorTabClose = ({ ids }: { ids: Array<string> }) => {
   const { closeEditors } = useEditors();
+  const { closeActiveTabs } = useKnownHotkeys();
   return (
     <Flex alignItems='center' className='editor-tab-close'>
       <Button
@@ -72,7 +98,8 @@ const EditorTabClose = ({ ids }: { ids: Array<string> }) => {
           closeEditors(ids);
         }}
         onKeyDown={e => e.stopPropagation()}
-        aria-label='Close tab'
+        aria-label={closeActiveTabs.label}
+        title={closeActiveTabs.label}
       />
     </Flex>
   );

--- a/app/neo/editors/process/ProcessEditor.tsx
+++ b/app/neo/editors/process/ProcessEditor.tsx
@@ -3,6 +3,7 @@ import { useHref, useLocation } from 'react-router';
 import { useWorkspace } from '~/data/workspace-api';
 import { baseUrl } from '~/data/ws-base';
 import { useThemeMode, useUpdateTheme } from '~/theme/useUpdateTheme';
+import { useHotkeyDispatcher } from '~/utils/hotkeys';
 import { type Editor, PROCESS_EDITOR_SUFFIX } from '../editor';
 import { useFrameMessageHandler } from './message/useFrameMessageHandler';
 
@@ -23,6 +24,7 @@ const updateFrameTheme = (frame: RefObject<HTMLIFrameElement | null>, theme: str
 
 export const ProcessEditor = ({ id, project, path, name }: Editor) => {
   const frame = useRef<HTMLIFrameElement>(null);
+  useHotkeyDispatcher(frame);
   const theme = useThemeMode();
   const ws = useWorkspace();
   const editorUrl = useHref(

--- a/app/neo/settings/AnimationSettingsMenu.tsx
+++ b/app/neo/settings/AnimationSettingsMenu.tsx
@@ -14,16 +14,24 @@ import {
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useParams } from 'react-router';
 import { useStopBpmEngine } from '~/data/project-api';
-import { useSettings, type AnimationFollowMode } from './useSettings';
+import { useKnownHotkeys } from '~/utils/hotkeys';
+import { speedModes, useSettings, type AnimationFollowMode } from './useSettings';
 
 export const AnimationSettingsMenu = () => {
   const { animation, enableAnimation, animationSpeed, animationMode } = useSettings();
   const { stopBpmEngine } = useStopBpmEngine();
   const { app, pmv } = useParams();
+  const texts = useKnownHotkeys();
+
   return (
     <DropdownMenuGroup>
       <DropdownMenuLabel>Animation</DropdownMenuLabel>
-      <DropdownMenuCheckboxItem checked={animation.animate} onCheckedChange={enableAnimation} aria-label='Toggle animation'>
+      <DropdownMenuCheckboxItem
+        checked={animation.animate}
+        onCheckedChange={enableAnimation}
+        aria-label={texts.toggleAnimation.label}
+        title={texts.toggleAnimation.label}
+      >
         Enabled
       </DropdownMenuCheckboxItem>
       <DropdownMenuItem
@@ -38,34 +46,24 @@ export const AnimationSettingsMenu = () => {
         Reset
       </DropdownMenuItem>
       <DropdownMenuSub>
-        <DropdownMenuSubTrigger aria-label='Animation speed'>
+        <DropdownMenuSubTrigger aria-label={texts.animationSpeed.label} title={texts.animationSpeed.label}>
           <IvyIcon icon={IvyIcons.Clock} />
           <span>Speed</span>
         </DropdownMenuSubTrigger>
         <DropdownMenuPortal>
           <DropdownMenuSubContent sideOffset={6} collisionPadding={10}>
             <DropdownMenuRadioGroup value={animation.speed.toString()} onValueChange={animationSpeed}>
-              <DropdownMenuRadioItem value='0' aria-label='fastest'>
-                fastest
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value='25' aria-label='fast'>
-                fast
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value='50' aria-label='normal'>
-                normal
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value='75' aria-label='slow'>
-                slow
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value='100' aria-label='slowest'>
-                slowest
-              </DropdownMenuRadioItem>
+              {speedModes.map(({ value, label }) => (
+                <DropdownMenuRadioItem key={value} value={value.toString()} aria-label={label}>
+                  {label}
+                </DropdownMenuRadioItem>
+              ))}
             </DropdownMenuRadioGroup>
           </DropdownMenuSubContent>
         </DropdownMenuPortal>
       </DropdownMenuSub>
       <DropdownMenuSub>
-        <DropdownMenuSubTrigger>
+        <DropdownMenuSubTrigger aria-label={texts.animationMode.label} title={texts.animationMode.label}>
           <IvyIcon icon={IvyIcons.Process} />
           <span>Mode</span>
         </DropdownMenuSubTrigger>

--- a/app/neo/settings/ThemeSettings.tsx
+++ b/app/neo/settings/ThemeSettings.tsx
@@ -6,16 +6,32 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   IvyIcon,
+  toast,
   useTheme,
   type Theme
 } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
+import { useKnownHotkeys } from '~/utils/hotkeys';
+const themes = ['light', 'dark', 'system'] as const;
+
+export const useCycleTheme = () => {
+  const { theme, setTheme } = useTheme();
+  const cycleTheme = () => {
+    const currentIndex = themes.indexOf(theme);
+    const nextTheme = themes[(currentIndex + 1) % themes.length];
+    setTheme(nextTheme);
+    toast.info(`Theme: ${nextTheme}`);
+  };
+  return cycleTheme;
+};
 
 export const ThemeSettings = () => {
   const { theme, setTheme } = useTheme();
+  const { changeTheme } = useKnownHotkeys();
+
   return (
     <DropdownMenuSub>
-      <DropdownMenuSubTrigger aria-label='Theme switch' data-theme={theme}>
+      <DropdownMenuSubTrigger aria-label={changeTheme.label} title={changeTheme.label} data-theme={theme}>
         <IvyIcon icon={IvyIcons.DarkMode} />
         <span>Theme</span>
         <DropdownMenuPortal>

--- a/app/neo/settings/useSettings.ts
+++ b/app/neo/settings/useSettings.ts
@@ -1,10 +1,20 @@
+import { toast } from '@axonivy/ui-components';
 import { useEffect } from 'react';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { AnimationSettings } from '~/data/neo-jsonrpc';
 import type { NeoClient } from '~/data/neo-protocol';
 
-export type AnimationFollowMode = 'all' | 'currentProcess' | 'openProcesses' | 'noDialogProcesses' | 'noEmbeddedProcesses';
+const animationFollowModes = ['all', 'currentProcess', 'openProcesses', 'noDialogProcesses', 'noEmbeddedProcesses'] as const;
+export type AnimationFollowMode = (typeof animationFollowModes)[number];
+
+export const speedModes = [
+  { value: 0, label: 'fastest' },
+  { value: 25, label: 'fast' },
+  { value: 50, label: 'normal' },
+  { value: 75, label: 'slow' },
+  { value: 100, label: 'slowest' }
+];
 
 type SettingsState = {
   animation: AnimationSettings;
@@ -30,4 +40,29 @@ export const useSyncSettings = (client?: NeoClient) => {
   useEffect(() => {
     client?.animationSettings(animation);
   }, [animation, client]);
+};
+
+export const useCycleAnimationSettings = () => {
+  const { animation, enableAnimation, animationMode, animationSpeed } = useSettings();
+
+  const cycleAnimationMode = () => {
+    const currentIndex = animationFollowModes.indexOf(animation.mode);
+    const nextMode = animationFollowModes[(currentIndex + 1) % animationFollowModes.length];
+    animationMode(nextMode);
+    toast.info(`Animation mode: ${nextMode}`);
+  };
+
+  const cycleAnimationSpeed = () => {
+    const currentIndex = speedModes.findIndex(s => s.value === animation.speed);
+    const nextIndex = (currentIndex + 1) % speedModes.length;
+    const nextSpeed = speedModes[nextIndex];
+
+    animationSpeed(nextSpeed.value.toString());
+    toast.info(`Animation speed: ${nextSpeed.label}`);
+  };
+  const toggleAnimation = () => {
+    enableAnimation(!animation.animate);
+    toast.info(animation.animate ? 'Animation disabled' : 'Animation enabled');
+  };
+  return { cycleAnimationMode, cycleAnimationSpeed, toggleAnimation };
 };

--- a/app/routes/configurations/overview.tsx
+++ b/app/routes/configurations/overview.tsx
@@ -20,6 +20,7 @@ export default function Index() {
   const { data, isPending } = useGroupedConfigurations();
   const { filteredGroups, search, setSearch } = useFilteredGroups(data ?? [], (c: ConfigurationIdentifier) => `${c.project.pmv} ${c.path}`);
   const { createConfigurationEditor } = useCreateEditor();
+
   return (
     <Overview title='Configurations' description={configDescription} search={search} onSearchChange={setSearch} isPending={isPending}>
       {filteredGroups.map(({ project, artifacts }) => (

--- a/app/routes/workspace-layout.tsx
+++ b/app/routes/workspace-layout.tsx
@@ -1,4 +1,15 @@
-import { Field, Flex, Label, ResizableHandle, ResizablePanel, ResizablePanelGroup, Separator, Switch } from '@axonivy/ui-components';
+import {
+  Field,
+  Flex,
+  Label,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+  Separator,
+  Switch,
+  useHotkeys
+} from '@axonivy/ui-components';
+import { useRef } from 'react';
 import { Outlet, useParams } from 'react-router';
 import { Navigation } from '~/neo/Navigation';
 import { WebBrowser } from '~/neo/browser/WebBrowser';
@@ -9,11 +20,23 @@ import { EditorsControl } from '~/neo/control-bar/EditorControl';
 import { EditorTabs } from '~/neo/control-bar/EditorTabs';
 import { MountedEditor } from '~/neo/editors/MountedEditor';
 import { renderEditor, useEditors } from '~/neo/editors/useEditors';
+import { useKnownHotkeys } from '~/utils/hotkeys';
 
 export default function Index() {
   const { editors } = useEditors();
   const { browser } = useWebBrowser();
   const { ws } = useParams();
+  const firstWebbrowserElement = useRef<HTMLButtonElement>(null);
+  const { openSimulation } = useKnownHotkeys();
+  useHotkeys(openSimulation.hotkey, () => {
+    browser.toggle();
+    if (!browser.openState) {
+      setTimeout(() => {
+        firstWebbrowserElement.current?.focus();
+      }, 0);
+    }
+  });
+
   return (
     <NeoClientProvider>
       <ControlBar>
@@ -22,7 +45,7 @@ export default function Index() {
           <Flex alignItems='center' gap={1} style={{ paddingInline: 'var(--size-2)', marginInlineStart: 'auto', flex: '0 0 auto' }}>
             <EditorsControl />
             <Separator orientation='vertical' style={{ margin: 'var(--size-2)' }} />
-            <Field direction='row' alignItems='center' gap={2}>
+            <Field direction='row' alignItems='center' gap={2} title={openSimulation.label} aria-label={openSimulation.label}>
               <Label>Simulate</Label>
               <Switch checked={browser.openState} onClick={browser.toggle} />
             </Field>
@@ -43,9 +66,10 @@ export default function Index() {
             </div>
           </Flex>
         </ResizablePanel>
-        <ResizableHandle style={{ width: 3, backgroundColor: 'var(--N200)' }} />
+
+        <ResizableHandle style={{ width: 3, height: 'calc(100% - 42px)', backgroundColor: 'var(--N200)' }} />
         <ResizablePanel ref={browser.panelRef} id='Browser' collapsible defaultSize={0} maxSize={70} minSize={10}>
-          <WebBrowser />
+          <WebBrowser firstWebbrowserElement={firstWebbrowserElement} />
         </ResizablePanel>
       </ResizablePanelGroup>
     </NeoClientProvider>

--- a/app/utils/hotkeys.ts
+++ b/app/utils/hotkeys.ts
@@ -1,0 +1,179 @@
+import { hotkeyText } from '@axonivy/ui-components';
+import { useEffect, useMemo, type RefObject } from 'react';
+
+type KnownHotkey = { hotkey: string; label: string; keyCode?: string };
+
+export const useKnownHotkeys = (overviewAddTitle?: string) => {
+  const openHome = useMemo<KnownHotkey>(() => {
+    const hotkey = 'mod+alt+H';
+    const keyCode = 'KeyH';
+    return { hotkey, label: `Home (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  const openWorkspaces = useMemo<KnownHotkey>(() => {
+    const hotkey = 'mod+alt+W';
+    const keyCode = 'KeyW';
+    return { hotkey, label: `Workspaces (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  const openProcesses = useMemo<KnownHotkey>(() => {
+    const hotkey = 'mod+alt+P';
+    const keyCode = 'KeyP';
+    return { hotkey, label: `Processes (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  const openForms = useMemo<KnownHotkey>(() => {
+    const hotkey = 'mod+alt+F';
+    const keyCode = 'KeyF';
+    return { hotkey, label: `Forms (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  const openDataClasses = useMemo<KnownHotkey>(() => {
+    const hotkey = 'mod+alt+D';
+    const keyCode = 'KeyD';
+    return { hotkey, label: `Data Classes (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  const openConfigs = useMemo<KnownHotkey>(() => {
+    const hotkey = 'mod+alt+C';
+    const keyCode = 'KeyC';
+    return { hotkey, label: `Configurations (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  const closeAllTabs = useMemo<KnownHotkey>(() => {
+    const hotkey = 'shift+alt+A';
+    const keyCode = 'KeyA';
+    return { hotkey, label: `Close All Tabs (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  const closeActiveTabs = useMemo<KnownHotkey>(() => {
+    const hotkey = 'shift+alt+W';
+    const keyCode = 'KeyW';
+    return { hotkey, label: `Close Tab (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  const openSimulation = useMemo<KnownHotkey>(() => {
+    const hotkey = 'shift+S';
+    const keyCode = 'KeyS';
+    return { hotkey, label: `Open Simulation (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  const toggleAnimation = useMemo<KnownHotkey>(() => {
+    const hotkey = 'shift+A';
+    const keyCode = 'KeyA';
+    return { hotkey, label: `Toggle Animation (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  const animationSpeed = useMemo<KnownHotkey>(() => {
+    const hotkey = 'shift+R';
+    const keyCode = 'KeyR';
+    return { hotkey, label: `Animation Speed (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  const animationMode = useMemo<KnownHotkey>(() => {
+    const hotkey = 'shift+M';
+    const keyCode = 'KeyM';
+    return { hotkey, label: `Animation Mode (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  const changeTheme = useMemo<KnownHotkey>(() => {
+    const hotkey = 'shift+T';
+    const keyCode = 'KeyT';
+    return { hotkey, label: `Theme Switch (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  const addElement = useMemo<KnownHotkey>(() => {
+    const hotkey = 'A';
+    return { hotkey, label: `${overviewAddTitle} (${hotkeyText(hotkey)})` };
+  }, [overviewAddTitle]);
+
+  const deleteElement = useMemo<KnownHotkey>(() => {
+    const hotkey = 'Delete';
+    return { hotkey, label: `Delete selected Element (${hotkeyText(hotkey)})` };
+  }, []);
+
+  const importFromFile = useMemo<KnownHotkey>(() => {
+    const hotkey = 'I';
+    return { hotkey, label: `Import from File (${hotkeyText(hotkey)})` };
+  }, []);
+
+  const importFromMarket = useMemo<KnownHotkey>(() => {
+    const hotkey = 'M';
+    return { hotkey, label: `Import from Market (${hotkeyText(hotkey)})` };
+  }, []);
+
+  const focusTabs = useMemo<KnownHotkey>(() => {
+    const hotkey = 'mod+alt+1';
+    const keyCode = 'Digit1';
+    return { hotkey, label: `Focus Tabs (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  const focusNav = useMemo<KnownHotkey>(() => {
+    const hotkey = 'mod+alt+2';
+    const keyCode = 'Digit2';
+    return { hotkey, label: `Focus Navigation (${hotkeyText(hotkey)})`, keyCode };
+  }, []);
+
+  return {
+    openHome,
+    openWorkspaces,
+    openProcesses,
+    openDataClasses,
+    openForms,
+    openConfigs,
+    closeAllTabs,
+    closeActiveTabs,
+    openSimulation,
+    toggleAnimation,
+    animationSpeed,
+    animationMode,
+    changeTheme,
+    addElement,
+    deleteElement,
+    importFromFile,
+    importFromMarket,
+    focusNav,
+    focusTabs
+  };
+};
+
+export const useHotkeyDispatcher = (iframe: RefObject<HTMLIFrameElement | null>) => {
+  const hotkeys = useKnownHotkeys();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      for (const hotkeyObj of Object.values(hotkeys)) {
+        if (hotkeyObj.keyCode === undefined) continue;
+        const keys = hotkeyObj.hotkey.toLowerCase().split('+');
+        const shiftPressed = keys.includes('shift');
+        const altPressed = keys.includes('alt');
+        const ctrlPressed = keys.includes('mod');
+        const keyCode = hotkeyObj.keyCode;
+
+        if (event.key.toLowerCase() === keys[keys.length - 1] && event.shiftKey === shiftPressed && event.altKey === altPressed) {
+          const customEvent = new KeyboardEvent('keydown', {
+            key: event.key,
+            code: keyCode,
+            keyCode: event.keyCode,
+            bubbles: true,
+            cancelable: true,
+            shiftKey: shiftPressed,
+            altKey: altPressed,
+            ctrlKey: ctrlPressed,
+            metaKey: ctrlPressed
+          });
+
+          iframe.current?.contentWindow?.parent.document.dispatchEvent(customEvent);
+          break;
+        }
+      }
+    };
+
+    const frameWindow = iframe.current?.contentWindow;
+    frameWindow?.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      frameWindow?.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [iframe, hotkeys]);
+};


### PR DESCRIPTION
I added the following shortcuts/hotkeys for neo:
- Set focus on first tab (shift + 1)
- Set focus on first navigation element (shift + 2)

Overview-Page
- Add Tile (A)
- Delete selected Tile (Delete)
- Import Project (from Market with "M") (from File with "I")

ControlBar
- Close Active Tab (shift + alt + W)
- Close all Tabs (shift + alt + A)
- Open Simulation (and focus inside Webbrowser) (shift + S)

Navigation
- Switch directly to Home (mod + alt + H)
- Switch directly to Workspaces (mod + alt + W)
- Switch directly to Forms (mod + alt + F)
- Switch directly to Data Classes (mod + alt + D)
- Switch directly to Configurations (mod + alt + C)

Settings
- Toggle Animation (shift + A)
- Change Animation Mode (shift + M)
- Change Animation Speed (shift + R)
- Change Theme (shift + T)

Other improvements
- Added shortcut dispatcher for iframe, so shortcuts work even if you are inside an iframe (process editor/webbrowser)
- Added hover to tiles
- Added autofocus on searchinput if overview is opened

Open ToDo:
- (maybe) Resize Simulation (shift + alt + S)
- Add Tests

![neoShortcuts](https://github.com/user-attachments/assets/ebd35674-d8ec-425a-ad9f-df320f33c619)

