### PR TITLE
Upload sbom to maven artifactory to re-integrate it in product build

### DIFF
--- a/.ivy/raise-version.sh
+++ b/.ivy/raise-version.sh
@@ -2,6 +2,7 @@
 set -e
 
 mvn --batch-mode -f pom.xml versions:set versions:commit -DnewVersion=${1}
+mvn --batch-mode -f build/sbom/pom.xml versions:set versions:commit -DnewVersion=${1}
 mvn --batch-mode -f playwright/neo-test-project/pom.xml versions:set versions:commit -DnewVersion=${1}
 mvn --batch-mode -f playwright/tests/screenshots/pom.xml versions:set versions:commit -DnewVersion=${1}
 

--- a/build/sbom/Jenkinsfile
+++ b/build/sbom/Jenkinsfile
@@ -15,13 +15,14 @@ pipeline {
         script {
           if (isReleasingBranch()) {
             docker.build('node', '-f build/Dockerfile.node .').inside {
-              withCredentials([string(credentialsId: 'dependency-track', variable: 'API_KEY')]) {
-                sh 'npm run update:axonivy:next'
-                sh 'npm install'
-                sh 'npm run sbom'
-                def version = sh (script: "node -p \"require('./package.json').version\"", returnStdout: true)
-                uploadBOM(projectName: 'neo', projectVersion: version, bomFile: 'bom.json')
-              }
+              sh 'npm run update:axonivy:next'
+              sh 'npm install'
+              sh 'npm run sbom'
+              def version = sh (script: "node -p \"require('./package.json').version\"", returnStdout: true)
+              uploadBOM(projectName: 'neo', projectVersion: version, bomFile: 'bom.json')              
+            }
+            docker.build('maven-build', '-f build/Dockerfile.maven .').inside {
+              maven cmd: '-f build/sbom/pom.xml clean deploy'
             }
           }
         }

--- a/build/sbom/pom.xml
+++ b/build/sbom/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>ch.ivyteam.neo</groupId>
+  <artifactId>neo-designer-bom</artifactId>
+  <version>13.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>nexus.ivyteam.io</id>
+      <url>https://nexus.ivyteam.io/repository/maven-snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>attach-json</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.basedir}/../../bom.json</file>
+                  <type>json</type>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
First shot to upload the bom to maven artifactory so that I can re-integrate it in the product build. I don't want to have a re-integration over dtrack.

We could discuss that we upload the sbom file, when we also upload the neo designer to maven artifactory. 

![image](https://github.com/user-attachments/assets/6799a83a-31bd-45b7-b23d-a02d86908221)
