### PR TITLE
XIVY-15096 Integrate CMS-Editor into NEO

### DIFF
--- a/app/neo/editors/cms/CmsEditor.tsx
+++ b/app/neo/editors/cms/CmsEditor.tsx
@@ -1,0 +1,25 @@
+import { CmsEditor as App, ClientContextProvider } from '@axonivy/cms-editor';
+import { ReadonlyProvider, ThemeProvider } from '@axonivy/ui-components';
+import type { Editor } from '../editor';
+import { useWebSocket } from '../useWebSocket';
+import { CmsClientNeo } from './cms-client';
+import { useActionHandler } from './useActionHandler';
+
+export const CmsEditor = ({ project }: Editor) => {
+  const actionHandler = useActionHandler();
+  const client = useWebSocket<CmsClientNeo>(CmsClientNeo.webSocketUrl, connection =>
+    CmsClientNeo.startNeoMessageClient(connection, actionHandler)
+  );
+  if (!client) {
+    return null;
+  }
+  return (
+    <ClientContextProvider client={client}>
+      <ThemeProvider disabled>
+        <ReadonlyProvider readonly={project.isIar ?? false}>
+          <App context={{ app: project.app, pmv: project.pmv }} />
+        </ReadonlyProvider>
+      </ThemeProvider>
+    </ClientContextProvider>
+  );
+};

--- a/app/neo/editors/cms/cms-client.ts
+++ b/app/neo/editors/cms/cms-client.ts
@@ -1,0 +1,24 @@
+import { ClientJsonRpc } from '@axonivy/cms-editor';
+import type { CmsActionArgs } from '@axonivy/cms-editor-protocol';
+import type { MessageConnection } from '@axonivy/jsonrpc';
+
+export type CmsActionHandler = (action: CmsActionArgs) => void;
+
+export class CmsClientNeo extends ClientJsonRpc {
+  private actionHandler: CmsActionHandler;
+
+  constructor(connection: MessageConnection, actionHandler: CmsActionHandler) {
+    super(connection);
+    this.actionHandler = actionHandler;
+  }
+
+  action(action: CmsActionArgs) {
+    this.actionHandler(action);
+  }
+
+  public static async startNeoMessageClient(connection: MessageConnection, actionHandler: (action: CmsActionArgs) => void) {
+    const client = new CmsClientNeo(connection, actionHandler);
+    await client.start();
+    return client;
+  }
+}

--- a/app/neo/editors/cms/useActionHandler.ts
+++ b/app/neo/editors/cms/useActionHandler.ts
@@ -1,0 +1,11 @@
+import { useCallback } from 'react';
+import type { CmsActionHandler } from './cms-client';
+
+export const useActionHandler = () => {
+  return useCallback<CmsActionHandler>(action => {
+    if (action.actionId === 'openUrl') {
+      window.open(action.payload);
+      return;
+    }
+  }, []);
+};

--- a/app/neo/editors/editor.ts
+++ b/app/neo/editors/editor.ts
@@ -1,7 +1,7 @@
 import { IvyIcons } from '@axonivy/ui-icons';
 import type { ProjectIdentifier } from '~/data/project-api';
 
-export type EditorType = 'processes' | 'forms' | 'configurations' | 'dataclasses' | 'variables';
+export type EditorType = 'processes' | 'forms' | 'configurations' | 'dataclasses' | 'variables' | 'cms';
 
 // if you change the Editor type increase the zustand version too
 export type Editor = { id: string; type: EditorType; icon: IvyIcons; name: string; project: ProjectIdentifier; path: string };
@@ -12,6 +12,7 @@ export const DATACLASS_EDITOR_SUFFIX = '.d.json';
 export const CONFIG_EDITOR_YAML_SUFFIX = '.yaml';
 export const CONFIG_EDITOR_XML_SUFFIX = '.xml';
 export const VARIABLES_EDITOR_SUFFIX = 'variables.yaml';
+export const CMS_EDITOR_SUFFIX = 'cms';
 
 export const DIALOG_PROCESS_EDITOR_SUFFIX = `Process${PROCESS_EDITOR_SUFFIX}`;
 export const DIALOG_DATA_EDITOR_SUFFIX = `Data${DATACLASS_EDITOR_SUFFIX}`;

--- a/app/neo/editors/useCreateEditor.test.ts
+++ b/app/neo/editors/useCreateEditor.test.ts
@@ -254,4 +254,17 @@ describe('createEditorFromPath', () => {
       view.result.current.createEditorFromPath({ app: 'designer', pmv: 'workflow-demos' }, 'dataclasses/form/Data.d.json', 'dataclasses')
     ).to.be.deep.equals(result);
   });
+
+  test('cms', () => {
+    const result: Editor = {
+      id: '/test-ws/configurations/designer/workflow-demos/cms',
+      type: 'cms',
+      icon: IvyIcons.Cms,
+      name: 'cms',
+      project: { app: 'designer', pmv: 'workflow-demos' },
+      path: 'cms'
+    };
+    const view = renderHook(() => useCreateEditor());
+    expect(view.result.current.createCmsEditor({ app: 'designer', pmv: 'workflow-demos' })).to.be.deep.equals(result);
+  });
 });

--- a/app/neo/editors/useCreateEditor.tsx
+++ b/app/neo/editors/useCreateEditor.tsx
@@ -7,6 +7,7 @@ import type { Process } from '~/data/process-api';
 import type { ProjectIdentifier } from '~/data/project-api';
 import { lastSegment } from '~/utils/path';
 import {
+  CMS_EDITOR_SUFFIX,
   CONFIG_EDITOR_XML_SUFFIX,
   CONFIG_EDITOR_YAML_SUFFIX,
   DATACLASS_EDITOR_SUFFIX,
@@ -30,6 +31,7 @@ export const useCreateEditor = () => {
     },
     createConfigurationEditor: ({ path, project }: ConfigurationIdentifier): Editor =>
       createEditor(ws, typeFromPath(path), project, path, lastSegment(path)),
+    createCmsEditor: (project: ProjectIdentifier): Editor => createEditor(ws, 'cms', project, 'cms', CMS_EDITOR_SUFFIX),
     createDataClassEditor: ({ simpleName, path, dataClassIdentifier: { project } }: DataClassBean): Editor =>
       createEditor(ws, 'dataclasses', project, path, simpleName),
     createEditorFromPath: (project: ProjectIdentifier, path: string, editorType?: EditorType): Editor =>
@@ -38,7 +40,7 @@ export const useCreateEditor = () => {
 };
 
 const createEditor = (ws: string, editorType: EditorType, project: ProjectIdentifier, path: string, name: string): Editor => {
-  const routeEditorType = editorType === 'variables' ? 'configurations' : editorType;
+  const routeEditorType = editorType === 'variables' || editorType === 'cms' ? 'configurations' : editorType;
   const encodedPath = encodeURI(path);
   const id = `/${ws}/${routeEditorType}/${project.app}/${project.pmv}/${encodedPath}`;
   return {
@@ -72,6 +74,9 @@ const typeFromPath = (path: string): EditorType => {
   if (path.endsWith(VARIABLES_EDITOR_SUFFIX)) {
     return 'variables';
   }
+  if (path.endsWith(CMS_EDITOR_SUFFIX)) {
+    return 'cms';
+  }
   if (path.endsWith(CONFIG_EDITOR_YAML_SUFFIX) || path.endsWith(CONFIG_EDITOR_XML_SUFFIX)) {
     return 'configurations';
   }
@@ -86,6 +91,8 @@ const editorIcon = (editorType: EditorType) => {
     case 'variables':
     case 'configurations':
       return IvyIcons.Tool;
+    case 'cms':
+      return IvyIcons.Cms;
     case 'dataclasses':
       return IvyIcons.Database;
   }

--- a/app/neo/editors/useEditors.tsx
+++ b/app/neo/editors/useEditors.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { CmsEditor } from './cms/CmsEditor';
 import { DataClassEditor } from './dataclass/DataClassEditor';
 import { DIALOG_DATA_EDITOR_SUFFIX, DIALOG_PROCESS_EDITOR_SUFFIX, type Editor } from './editor';
 import { FormEditor } from './form/FormEditor';
@@ -120,6 +121,8 @@ export const renderEditor = (editor: Editor) => {
       return <FormEditor {...editor} />;
     case 'variables':
       return <VariableEditor {...editor} />;
+    case 'cms':
+      return <CmsEditor {...editor} />;
     case 'configurations':
       return <TextEditor {...editor} />;
     case 'dataclasses':

--- a/app/routes/configurations/editor.tsx
+++ b/app/routes/configurations/editor.tsx
@@ -1,9 +1,13 @@
-import editorStylesHref from '@axonivy/variable-editor/lib/editor.css?url';
+import cmsEditorStylesHref2 from '@axonivy/cms-editor/lib/editor.css?url';
+import variableEditorStylesHref from '@axonivy/variable-editor/lib/editor.css?url';
 import { type LinksFunction, type MetaFunction } from 'react-router';
 import { editorMetaFunctionProvider } from '~/metaFunctionProvider';
 import { useRestoreEditor } from '~/neo/editors/useRestoreEditor';
 
-export const links: LinksFunction = () => [{ rel: 'stylesheet', href: editorStylesHref }];
+export const links: LinksFunction = () => [
+  { rel: 'stylesheet', href: cmsEditorStylesHref2 },
+  { rel: 'stylesheet', href: variableEditorStylesHref }
+];
 
 export const meta: MetaFunction = editorMetaFunctionProvider('Axon Ivy Configuration Editor');
 

--- a/app/routes/configurations/overview.tsx
+++ b/app/routes/configurations/overview.tsx
@@ -6,7 +6,7 @@ import { configDescription } from '~/neo/artifact/artifact-description';
 import { ArtifactCard, cardStylesLink } from '~/neo/artifact/ArtifactCard';
 import { ArtifactGroup } from '~/neo/artifact/ArtifactGroup';
 import { useFilteredGroups } from '~/neo/artifact/useFilteredGroups';
-import { type Editor } from '~/neo/editors/editor';
+import { CMS_EDITOR_SUFFIX, type Editor } from '~/neo/editors/editor';
 import { useCreateEditor } from '~/neo/editors/useCreateEditor';
 import { useEditors } from '~/neo/editors/useEditors';
 import { Overview } from '~/neo/Overview';
@@ -19,12 +19,22 @@ export const meta: MetaFunction = overviewMetaFunctionProvider('Configurations')
 export default function Index() {
   const { data, isPending } = useGroupedConfigurations();
   const { filteredGroups, search, setSearch } = useFilteredGroups(data ?? [], (c: ConfigurationIdentifier) => `${c.project.pmv} ${c.path}`);
-  const { createConfigurationEditor } = useCreateEditor();
+  const { createConfigurationEditor, createCmsEditor } = useCreateEditor();
+  const { openEditor } = useEditors();
 
   return (
     <Overview title='Configurations' description={configDescription} search={search} onSearchChange={setSearch} isPending={isPending}>
       {filteredGroups.map(({ project, artifacts }) => (
         <ArtifactGroup project={project} key={project}>
+          {(search.length === 0 || CMS_EDITOR_SUFFIX.startsWith(search.toLowerCase())) && (
+            <ArtifactCard
+              name={CMS_EDITOR_SUFFIX}
+              type='cms'
+              preview={<PreviewSVG />}
+              tooltip={CMS_EDITOR_SUFFIX}
+              onClick={() => openEditor(createCmsEditor(artifacts[0].project))}
+            />
+          )}
           {artifacts.map(config => {
             const editor = createConfigurationEditor(config);
             return <ConfigCard key={editor.id} {...editor} />;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "playwright"
       ],
       "dependencies": {
+        "@axonivy/cms-editor": "~13.1.0-next.18",
+        "@axonivy/cms-editor-protocol": "~13.1.0-next.18",
         "@axonivy/dataclass-editor": "~13.1.0-next.461",
         "@axonivy/dataclass-editor-protocol": "~13.1.0-next.461",
         "@axonivy/form-editor": "~13.1.0-next.599",
@@ -198,6 +200,28 @@
         "@types/json-schema": "^7.0.11"
       }
     },
+    "node_modules/@axonivy/cms-editor": {
+      "version": "13.1.0-next.18",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/cms-editor/-/cms-editor-13.1.0-next.18.tgz",
+      "integrity": "sha512-wN4/GUEJBZi72jZtPkfg1AeYN/+ZYXVoxhOfxQdI/N++7nI5VWdDypiA/EG1eoawKSX3uiicW6LSE7WJ9qILsg==",
+      "dependencies": {
+        "@axonivy/cms-editor-protocol": "13.1.0-next.18+450b0a3",
+        "@tanstack/react-virtual": "^3.12.0"
+      },
+      "peerDependencies": {
+        "@axonivy/jsonrpc": "~13.1.0-next",
+        "@axonivy/ui-components": "~13.1.0-next",
+        "@axonivy/ui-icons": "~13.1.0-next",
+        "@tanstack/react-query": "^5.64",
+        "@tanstack/react-query-devtools": "^5.64",
+        "react": "^18.2 || ^19.0"
+      }
+    },
+    "node_modules/@axonivy/cms-editor-protocol": {
+      "version": "13.1.0-next.18",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/cms-editor-protocol/-/cms-editor-protocol-13.1.0-next.18.tgz",
+      "integrity": "sha512-PyXOc9C6bboLfX0yovZegxouHNV4lvS8OCY6fI5Sb5ztX+4c33aP5Bh73k6fgmf1buxjKOZawxYpEKr+kM8r/A=="
+    },
     "node_modules/@axonivy/dataclass-editor": {
       "version": "13.1.0-next.461",
       "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/dataclass-editor/-/dataclass-editor-13.1.0-next.461.tgz",
@@ -282,11 +306,11 @@
       }
     },
     "node_modules/@axonivy/process-editor": {
-      "version": "13.1.0-next.1423",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/process-editor/-/process-editor-13.1.0-next.1423.tgz",
-      "integrity": "sha512-oA5c++OOpbrpcYl6JRLOAQruclmyzxnEJ6eintI4iP/6RmgIvI86OznmZcXWSkm1tBl/R6n9cxT68ShPtCCZDw==",
+      "version": "13.1.0-next.1424",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/process-editor/-/process-editor-13.1.0-next.1424.tgz",
+      "integrity": "sha512-J7mF0dEs6vb2+/xY/99i4pM+2e6/IZ8pznrpsFD3whU03dWwDjsyDj/LuO9dSn1s66lV0c58/XlurYawuehlEw==",
       "dependencies": {
-        "@axonivy/process-editor-protocol": "13.1.0-next.1423+20a27870",
+        "@axonivy/process-editor-protocol": "13.1.0-next.1424+029c491",
         "@eclipse-glsp/client": "2.3.0",
         "marked": "^15.0.6",
         "toastify-js": "1.12.0"
@@ -296,14 +320,14 @@
       }
     },
     "node_modules/@axonivy/process-editor-inscription": {
-      "version": "13.1.0-next.1423",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/process-editor-inscription/-/process-editor-inscription-13.1.0-next.1423.tgz",
-      "integrity": "sha512-0VW1ib+rLC1v3BZjfKNmeKnqqOWJ1jSxhHfFqQg+h5mnqztOjl7r19b8i9Lw2exMHeuDUAmmGwX36BMH7NtX5g==",
+      "version": "13.1.0-next.1424",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/process-editor-inscription/-/process-editor-inscription-13.1.0-next.1424.tgz",
+      "integrity": "sha512-G8NkrSR+1NpGJW4887le3aNcJsaapThhiiUJVtYs9LH0hAjmoKM9CGE8ZAp/9+xHkeddYC9OXbu6iUheaPYYYQ==",
       "dependencies": {
-        "@axonivy/process-editor": "13.1.0-next.1423+20a27870",
-        "@axonivy/process-editor-inscription-core": "13.1.0-next.1423+20a27870",
-        "@axonivy/process-editor-inscription-protocol": "13.1.0-next.1423+20a27870",
-        "@axonivy/process-editor-inscription-view": "13.1.0-next.1423+20a27870",
+        "@axonivy/process-editor": "13.1.0-next.1424+029c491",
+        "@axonivy/process-editor-inscription-core": "13.1.0-next.1424+029c491",
+        "@axonivy/process-editor-inscription-protocol": "13.1.0-next.1424+029c491",
+        "@axonivy/process-editor-inscription-view": "13.1.0-next.1424+029c491",
         "@codingame/monaco-vscode-editor-service-override": "1.83.3",
         "@codingame/monaco-vscode-languages-service-override": "1.83.3",
         "@codingame/monaco-vscode-model-service-override": "1.83.3",
@@ -316,11 +340,11 @@
       }
     },
     "node_modules/@axonivy/process-editor-inscription-core": {
-      "version": "13.1.0-next.1423",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/process-editor-inscription-core/-/process-editor-inscription-core-13.1.0-next.1423.tgz",
-      "integrity": "sha512-ywBh5Y6Sl/Elz4PcLm3cdmgYjFJCHgU4EL9YDWXTkpmQ8b5AUXdaTo2lYGBuvcXZEJ6qgvuZPaA8mDTMh0sFwQ==",
+      "version": "13.1.0-next.1424",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/process-editor-inscription-core/-/process-editor-inscription-core-13.1.0-next.1424.tgz",
+      "integrity": "sha512-p4f8srTrkXRjR53J0SoPR681Dp5FH5TGWv+96QAf++7ilJXJ4BgD+TsnI+f2xSa8xtfte/JZV9mPmw5gTqg7xA==",
       "dependencies": {
-        "@axonivy/process-editor-inscription-protocol": "13.1.0-next.1423+20a27870",
+        "@axonivy/process-editor-inscription-protocol": "13.1.0-next.1424+029c491",
         "monaco-editor": "^0.44.0",
         "monaco-editor-workers": "^0.44.0",
         "monaco-languageclient": "^6.6.1",
@@ -331,17 +355,17 @@
       }
     },
     "node_modules/@axonivy/process-editor-inscription-protocol": {
-      "version": "13.1.0-next.1423",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/process-editor-inscription-protocol/-/process-editor-inscription-protocol-13.1.0-next.1423.tgz",
-      "integrity": "sha512-HXUTc/NMRwwLUkTVJmRMSpSJRpixQdG454fExf9MSEIbsR+hrHd0Otm+VASns4gfesp5/eFxAqIUvrBXMblW3A=="
+      "version": "13.1.0-next.1424",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/process-editor-inscription-protocol/-/process-editor-inscription-protocol-13.1.0-next.1424.tgz",
+      "integrity": "sha512-rzuMez3lCMpRQVswzLvJXfZp9EtCVX+tFzAvektftpzx0vR4j907G3tSkt6izlrdChjmumfpkIp+nq/qaq9Quw=="
     },
     "node_modules/@axonivy/process-editor-inscription-view": {
-      "version": "13.1.0-next.1423",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/process-editor-inscription-view/-/process-editor-inscription-view-13.1.0-next.1423.tgz",
-      "integrity": "sha512-wduPgGg54r1SctZA6B0tPUxj74AJHfmTA61SWbJT6B31Ih4K0EyXyKuWXv6NOIgM1zpOaYbt37igNju+I+OtPw==",
+      "version": "13.1.0-next.1424",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/process-editor-inscription-view/-/process-editor-inscription-view-13.1.0-next.1424.tgz",
+      "integrity": "sha512-+kJsOx3/ruhUOyWpMBglZiiDbgajlzj37CbKiTHS+Ye56vL7PbBNslqaMIstkSWp2JV4mhpUQVvD7aOtRAOIbA==",
       "dependencies": {
-        "@axonivy/process-editor-inscription-core": "13.1.0-next.1423+20a27870",
-        "@axonivy/process-editor-inscription-protocol": "13.1.0-next.1423+20a27870",
+        "@axonivy/process-editor-inscription-core": "13.1.0-next.1424+029c491",
+        "@axonivy/process-editor-inscription-protocol": "13.1.0-next.1424+029c491",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-radio-group": "^1.2.3",
@@ -362,9 +386,9 @@
       }
     },
     "node_modules/@axonivy/process-editor-protocol": {
-      "version": "13.1.0-next.1423",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/process-editor-protocol/-/process-editor-protocol-13.1.0-next.1423.tgz",
-      "integrity": "sha512-uywjkTt4FOxqZB1VZnyVDUikwKlz88FmmzQXMPfLIZDWdZyX+w9bzhoO9fZxEDpqtoCv+nAng4Um0+NVg9yTpw==",
+      "version": "13.1.0-next.1424",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/process-editor-protocol/-/process-editor-protocol-13.1.0-next.1424.tgz",
+      "integrity": "sha512-dvAqYCOU/l8RIMj3vgsofFKEJmT+WC55e2WQ56tcyemfQwnx/VG+lkbAyXX0sacOczt7n0WQ0b+zpZfHRR8nug==",
       "dependencies": {
         "@eclipse-glsp/protocol": "2.3.0"
       }
@@ -14677,12 +14701,12 @@
       "version": "13.1.0-next",
       "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
       "dependencies": {
-        "@axonivy/process-editor": "~13.1.0-next.1423",
-        "@axonivy/process-editor-inscription": "~13.1.0-next.1423",
-        "@axonivy/process-editor-inscription-core": "~13.1.0-next.1423",
-        "@axonivy/process-editor-inscription-protocol": "~13.1.0-next.1423",
-        "@axonivy/process-editor-inscription-view": "~13.1.0-next.1423",
-        "@axonivy/process-editor-protocol": "~13.1.0-next.1423",
+        "@axonivy/process-editor": "~13.1.0-next.1424",
+        "@axonivy/process-editor-inscription": "~13.1.0-next.1424",
+        "@axonivy/process-editor-inscription-core": "~13.1.0-next.1424",
+        "@axonivy/process-editor-inscription-protocol": "~13.1.0-next.1424",
+        "@axonivy/process-editor-inscription-view": "~13.1.0-next.1424",
+        "@axonivy/process-editor-protocol": "~13.1.0-next.1424",
         "@codingame/monaco-vscode-editor-service-override": "1.83.3",
         "@codingame/monaco-vscode-languages-service-override": "1.83.3",
         "@codingame/monaco-vscode-model-service-override": "1.83.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "@axonivy/ui-icons": "~13.1.0-next.586",
     "@axonivy/variable-editor": "~13.1.0-next.609",
     "@axonivy/variable-editor-protocol": "~13.1.0-next.609",
+    "@axonivy/cms-editor": "~13.1.0-next.18",
+    "@axonivy/cms-editor-protocol": "~13.1.0-next.18",
     "@react-router/node": "^7.1.3",
     "@tanstack/react-query": "5.66.9",
     "@tanstack/react-query-devtools": "5.66.9",

--- a/playwright/tests/integration/cms.spec.ts
+++ b/playwright/tests/integration/cms.spec.ts
@@ -1,0 +1,15 @@
+import { type Page, test } from '@playwright/test';
+import { CmsEditor } from '../page-objects/cms-editor';
+import { Neo } from '../page-objects/neo';
+import { APP, TEST_PROJECT } from './constants';
+
+const openCms = async (page: Page) => {
+  const neo = await Neo.openEditor(page, `configurations/${APP}/${TEST_PROJECT}/cms`);
+  const editor = new CmsEditor(neo, 'cms');
+  await editor.expectOpen('/Labels');
+  return { neo, editor };
+};
+
+test('restore editor', async ({ page }) => {
+  await openCms(page);
+});

--- a/playwright/tests/integration/configs.spec.ts
+++ b/playwright/tests/integration/configs.spec.ts
@@ -18,10 +18,10 @@ test('navigate to configs', async ({ page }) => {
 test('search configs', async ({ page }) => {
   const neo = await Neo.openWorkspace(page);
   const overview = await neo.configs();
-  await expect(overview.cards).toHaveCount(2);
+  await expect(overview.cards).toHaveCount(3);
   await overview.search.fill('bla');
   await expect(overview.cards).toHaveCount(0);
 
   await overview.search.fill('cms');
-  await expect(overview.cards).toHaveCount(1);
+  await expect(overview.cards).toHaveCount(2);
 });

--- a/playwright/tests/page-objects/cms-editor.ts
+++ b/playwright/tests/page-objects/cms-editor.ts
@@ -1,0 +1,36 @@
+import { expect, type Locator } from '@playwright/test';
+import { Neo } from './neo';
+
+export class CmsEditor {
+  readonly editor: Locator;
+
+  constructor(
+    readonly neo: Neo,
+    readonly name: string
+  ) {
+    this.editor = neo.page.locator(`.editor[data-editor-type="cms"][data-editor-name="${name}"]`);
+  }
+
+  async expectOpen(cms?: string) {
+    await this.neo.controlBar.tab(this.name).expectActive();
+    await expect(this.editor).toBeVisible();
+    if (cms) {
+      await expect(this.rowByName(cms).row).toBeVisible();
+    }
+  }
+
+  rowByName(name: string) {
+    return new CmsEditorRow(this, name);
+  }
+}
+
+export class CmsEditorRow {
+  readonly row: Locator;
+
+  constructor(
+    readonly editor: CmsEditor,
+    readonly name: string
+  ) {
+    this.row = editor.editor.locator('.ui-table-row:not(.ui-message-row)').filter({ hasText: new RegExp(`^${name}$`) });
+  }
+}

--- a/webviews/process-editor/package.json
+++ b/webviews/process-editor/package.json
@@ -9,12 +9,12 @@
     "url": "https://github.com/axonivy/glsp-editor-client"
   },
   "dependencies": {
-    "@axonivy/process-editor": "~13.1.0-next.1423",
-    "@axonivy/process-editor-inscription": "~13.1.0-next.1423",
-    "@axonivy/process-editor-inscription-core": "~13.1.0-next.1423",
-    "@axonivy/process-editor-inscription-protocol": "~13.1.0-next.1423",
-    "@axonivy/process-editor-inscription-view": "~13.1.0-next.1423",
-    "@axonivy/process-editor-protocol": "~13.1.0-next.1423",
+    "@axonivy/process-editor": "~13.1.0-next.1424",
+    "@axonivy/process-editor-inscription": "~13.1.0-next.1424",
+    "@axonivy/process-editor-inscription-core": "~13.1.0-next.1424",
+    "@axonivy/process-editor-inscription-protocol": "~13.1.0-next.1424",
+    "@axonivy/process-editor-inscription-view": "~13.1.0-next.1424",
+    "@axonivy/process-editor-protocol": "~13.1.0-next.1424",
     "@codingame/monaco-vscode-editor-service-override": "1.83.3",
     "@codingame/monaco-vscode-languages-service-override": "1.83.3",
     "@codingame/monaco-vscode-model-service-override": "1.83.3",


### PR DESCRIPTION
@ivy-lmu Tried to integrate the CMS-Editor. It works but is this correct this way? Did I forgot something? I open the CMS-Editor with path "configurations/_app_/_pmv_/config/cms". I have also left the individual cms.yaml files in the config overview for now. But I think these should be removed in the future as soon as the cms-editor offers all basic functions. What do you think?

@ivy-lgi For some reason the details are not showing up in the CMS editor (see GIF), either I have an old version or I forgot to pass any information to the CMS editor. Just in case you're seeing something obvious that I've forgotten. 
...Nevermind, the problem was, that the engine i had running in the background was not up to date 😅 

![cms_in_neo](https://github.com/user-attachments/assets/bd76b90d-4bd3-4d44-87a9-47d3e2d28a6b)
