### PR TITLE
XIVY-15989 Load translations from engine

### DIFF
--- a/app/neo/Navigation.tsx
+++ b/app/neo/Navigation.tsx
@@ -11,7 +11,7 @@ import { IvyIcons } from '@axonivy/ui-icons';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink, useNavigate } from 'react-router';
-import { LanguageSelector } from '~/translation/LanguageSelector';
+import { LanguageSelector } from '~/neo/settings/LanguageSelector';
 import { useKnownHotkeys } from '~/utils/hotkeys';
 import { useNeoClient } from './client/useNeoClient';
 import { AnimationSettingsMenu } from './settings/AnimationSettingsMenu';

--- a/app/neo/browser/useWebBrowser.tsx
+++ b/app/neo/browser/useWebBrowser.tsx
@@ -6,7 +6,7 @@ type WebBrowserProviderState = {
   panelRef: React.RefObject<ImperativePanelHandle | null>;
   frameRef: React.RefObject<HTMLIFrameElement | null>;
   openState: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
-  openUrl: (url: string) => void;
+  openUrl: (url?: string) => void;
 };
 
 const browserSizes = [25, 40, 55, 70] as const;
@@ -17,8 +17,8 @@ export const WebBrowserProvider = ({ children }: { children: React.ReactNode }) 
   const panelRef = useRef<ImperativePanelHandle>(null);
   const frameRef = useRef<HTMLIFrameElement>(null);
   const openState = useState(false);
-  const openUrl = (url: string) => {
-    if (frameRef.current?.contentWindow) {
+  const openUrl = (url?: string) => {
+    if (frameRef.current?.contentWindow && url) {
       frameRef.current.contentWindow.location = url;
     }
   };
@@ -30,7 +30,7 @@ export const WebBrowserProvider = ({ children }: { children: React.ReactNode }) 
 export const useWebBrowser = () => {
   const context = useContext(WebBrowserProviderContext);
   const ws = useWorkspace();
-  const homeUrl = useMemo(() => (ws ? `${ws?.baseUrl}/dev-workflow-ui/faces/home.xhtml` : ''), [ws]);
+  const homeUrl = useMemo(() => (ws ? `${ws?.baseUrl}/dev-workflow-ui/faces/home.xhtml` : undefined), [ws]);
   if (context === undefined) throw new Error('useWebBrowser must be used within a WebBrowserProvider');
   const { panelRef, frameRef, openUrl } = context;
   const [open, setOpen] = context.openState;

--- a/app/neo/editors/process/ProcessEditor.tsx
+++ b/app/neo/editors/process/ProcessEditor.tsx
@@ -3,6 +3,7 @@ import { useHref, useLocation } from 'react-router';
 import { useWorkspace } from '~/data/workspace-api';
 import { baseUrl } from '~/data/ws-base';
 import { useThemeMode, useUpdateTheme } from '~/theme/useUpdateTheme';
+import { useUpdateLanguage } from '~/translation/useUpdateLanguage';
 import { useHotkeyDispatcher } from '~/utils/hotkeys';
 import { type Editor, PROCESS_EDITOR_SUFFIX } from '../editor';
 import { useFrameMessageHandler } from './message/useFrameMessageHandler';
@@ -33,6 +34,7 @@ export const ProcessEditor = ({ id, project, path, name }: Editor) => {
   const { pathname } = useLocation();
   useFrameMessageHandler(frame, project.app);
   useUpdateTheme(frame, updateFrameTheme);
+  useUpdateLanguage(frame, frame => frame.current?.contentWindow?.location.reload());
   useEffect(() => {
     if (pathname === id) {
       // trigger rerender of process to fix invisible connectors

--- a/app/neo/settings/LanguageSelector.tsx
+++ b/app/neo/settings/LanguageSelector.tsx
@@ -13,18 +13,18 @@ import { useTranslation } from 'react-i18next';
 
 export const LanguageSelector = () => {
   const { t } = useTranslation();
-
+  const languages = Object.keys(i18next.services.resourceStore.data);
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger aria-label={t('settings.languageSwitch')}>
-        <IvyIcon icon={IvyIcons.Cms} />
+        <IvyIcon icon={IvyIcons.WsStart} />
         <span>{t('settings.language')}</span>
         <DropdownMenuPortal>
           <DropdownMenuSubContent sideOffset={6} collisionPadding={10}>
-            <DropdownMenuRadioGroup value={i18next.language} onValueChange={i18next.changeLanguage}>
-              {i18next.languages.map(language => (
+            <DropdownMenuRadioGroup value={i18next.resolvedLanguage} onValueChange={i18next.changeLanguage}>
+              {languages.map(language => (
                 <DropdownMenuRadioItem key={language} value={language}>
-                  {language}
+                  {new Intl.DisplayNames([language], { type: 'language' }).of(language)}
                 </DropdownMenuRadioItem>
               ))}
             </DropdownMenuRadioGroup>

--- a/app/routes/workspaces/overview.tsx
+++ b/app/routes/workspaces/overview.tsx
@@ -26,10 +26,10 @@ import { useArtifactValidation } from '~/neo/artifact/validation';
 import { ControlBar } from '~/neo/control-bar/ControlBar';
 import { InfoPopover } from '~/neo/InfoPopover';
 import { Overview } from '~/neo/Overview';
+import { LanguageSelector } from '~/neo/settings/LanguageSelector';
 import { ThemeSettings } from '~/neo/settings/ThemeSettings';
 import { useSearch } from '~/neo/useSearch';
 import { useDownloadWorkspace } from '~/neo/workspace/useDownloadWorkspace';
-import { LanguageSelector } from '~/translation/LanguageSelector';
 import welcomeSvgUrl from './welcome.svg?url';
 import PreviewSVG from './workspace-preview.svg?react';
 

--- a/app/translation/translation.ts
+++ b/app/translation/translation.ts
@@ -1,5 +1,7 @@
 import i18n, { type Resource } from 'i18next';
 import LngDetector from 'i18next-browser-languagedetector';
+import ChainedBackend from 'i18next-chained-backend';
+import HttpBackend from 'i18next-http-backend';
 import resourcesToBackend from 'i18next-resources-to-backend';
 import { initReactI18next } from 'react-i18next';
 import deTranslationNeo from './neo/de.json';
@@ -35,13 +37,24 @@ const localTranslations: Resource = {
 export const initTranslation = async (debug = true) => {
   if (i18n.isInitializing || i18n.isInitialized) return;
   await i18n
-    .use(resourcesToBackend((lng: string, ns: string) => localTranslations[ns][lng]))
+    .use(ChainedBackend)
     .use(initReactI18next)
     .use(LngDetector)
     .init({
       debug,
       fallbackLng: Object.keys(localTranslations['common']),
       ns: Object.keys(localTranslations),
-      defaultNS: 'neo'
+      defaultNS: 'neo',
+      load: 'languageOnly',
+      partialBundledLanguages: true,
+      backend: {
+        backends: [HttpBackend, resourcesToBackend((lng: string, ns: string) => localTranslations[ns][lng])],
+        backendOptions: [
+          {
+            loadPath: '/webjars/locales/{{lng}}/{{ns}}.json'
+          }
+        ]
+      }
     });
+  i18n.loadLanguages(['fr', 'ja']);
 };

--- a/app/translation/useUpdateLanguage.ts
+++ b/app/translation/useUpdateLanguage.ts
@@ -1,0 +1,15 @@
+import i18next from 'i18next';
+import { useCallback, useEffect, type RefObject } from 'react';
+
+export const useUpdateLanguage = (
+  frame: RefObject<HTMLIFrameElement | null>,
+  callback: (frame: RefObject<HTMLIFrameElement | null>, theme: string) => void
+) => {
+  const updateLanguage = useCallback((lng: string) => callback(frame, lng), [callback, frame]);
+  useEffect(() => {
+    i18next.on('languageChanged', updateLanguage);
+    return () => {
+      i18next.off('languageChanged', updateLanguage);
+    };
+  }, [frame, updateLanguage]);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -6734,12 +6734,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.12.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
-      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "version": "22.13.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.13.tgz",
+      "integrity": "sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/react": {
@@ -15515,10 +15516,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unist-util-is": {
       "version": "6.0.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
       '/monaco-yaml-ivy': DEV_PROXY,
       '/dev-workflow-ui': DEV_PROXY,
       '/system': DEV_PROXY,
+      '/webjars': DEV_PROXY,
       '/designer': WEBSOCKET_PROXY,
       '/ivy-script-lsp': WEBSOCKET_PROXY,
       '/ivy-inscription-lsp': WEBSOCKET_PROXY,

--- a/webviews/process-editor/src/app.ts
+++ b/webviews/process-editor/src/app.ts
@@ -84,8 +84,12 @@ async function initMonaco(): Promise<void> {
   MonacoEditorUtil.configureInstance({ theme: 'light', debug, worker: { workerConstructor: worker.default } });
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 window.setMonacoTheme = (theme: ThemeMode) => {
   MonacoEditorUtil.setTheme(theme);
 };
+
+declare global {
+  interface Window {
+    setMonacoTheme: (theme: ThemeMode) => void;
+  }
+}

--- a/webviews/process-editor/src/i18n.ts
+++ b/webviews/process-editor/src/i18n.ts
@@ -1,6 +1,8 @@
 import { deCommonTranslation, deTranslation, enCommonTranslation, enTranslation } from '@axonivy/process-editor';
 import i18n, { type Resource } from 'i18next';
-import LanguageDetector from 'i18next-browser-languagedetector';
+import LngDetector from 'i18next-browser-languagedetector';
+import ChainedBackend from 'i18next-chained-backend';
+import HttpBackend from 'i18next-http-backend';
 import resourcesToBackend from 'i18next-resources-to-backend';
 import { initReactI18next } from 'react-i18next';
 
@@ -15,21 +17,26 @@ const localTranslations: Resource = {
   }
 };
 
-export const initTranslation = () => {
+export const initTranslation = async () => {
   if (i18n.isInitializing || i18n.isInitialized) return;
   i18n
+    .use(ChainedBackend)
     .use(initReactI18next)
-    .use(resourcesToBackend((lng: string, ns: string) => localTranslations[ns][lng]))
-    .use(LanguageDetector)
+    .use(LngDetector)
     .init({
       debug: true,
-      supportedLngs: ['en', 'de'],
       fallbackLng: 'en',
-      ns: ['process-editor'],
+      ns: ['process-editor', 'common'],
       defaultNS: 'process-editor',
-      resources: {
-        en: { 'process-editor': enTranslation, common: enCommonTranslation },
-        de: { 'process-editor': deTranslation, common: deCommonTranslation }
+      load: 'languageOnly',
+      partialBundledLanguages: true,
+      backend: {
+        backends: [HttpBackend, resourcesToBackend((lng: string, ns: string) => localTranslations[ns][lng])],
+        backendOptions: [
+          {
+            loadPath: '/webjars/locales/{{lng}}/{{ns}}.json'
+          }
+        ]
       }
     });
 };

--- a/webviews/process-editor/vite.config.ts
+++ b/webviews/process-editor/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig(() => {
       rollupOptions: {
         output: {
           manualChunks(id: string) {
-            if (id.includes('monaco-languageclient' || id.includes('vscode'))) {
+            if (id.includes('monaco-languageclient') || id.includes('vscode')) {
               return 'monaco-chunk';
             }
           }


### PR DESCRIPTION
- Load translation files from engine webapps folder (currently hardcoded ja and fr, need a way to tell neo what languages are installed)
- refresh process editor on language switch
- language switch show full language display name (e.g. 'English' instead of 'en')
- language switch shows all languages which are loaded