### PR TITLE
Enable react-router `unstable_optimizeDeps` future flag

### DIFF
--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -3,5 +3,10 @@ import type { Config } from '@react-router/dev/config';
 export default {
   ssr: false,
   buildDirectory: 'dist',
-  basename: '/neo/'
+  basename: '/neo/',
+  future: {
+    // This should fix an error in React Router on the first load of the dev server, which may occur when dependencies have changed.
+    // https://github.com/remix-run/react-router/issues/12786#issuecomment-2634033513
+    unstable_optimizeDeps: true
+  }
 } satisfies Config;


### PR DESCRIPTION
On first dev server start, sometimes this error shows up (mostly after a node_modules change)
![image](https://github.com/user-attachments/assets/a01af7d8-e55f-4961-9dec-d236be468938)
