### PR TITLE
Stabilize runtimelog view test

### DIFF
--- a/playwright/tests/integration/runtime-log.spec.ts
+++ b/playwright/tests/integration/runtime-log.spec.ts
@@ -1,30 +1,31 @@
-import { expect, type Page, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { Neo } from '../page-objects/neo';
 import { ProcessEditor } from '../page-objects/process-editor';
-import { APP, TEST_PROJECT } from './constants';
+import { RuntimeLogView } from '../page-objects/runtimelog-view';
 
-const startLogProcess = async (page: Page) => {
-  const neo = await Neo.openEditor(page, `processes/${APP}/${TEST_PROJECT}/processes/runtimeLog`);
-  await neo.navigation.resetAnimation();
-  await neo.navigation.disableAnimation();
+test('should render table and rows correctly', async ({ page }) => {
+  const neo = await Neo.openWorkspace(page);
+  const logView = new RuntimeLogView(neo);
+  await neo.navigation.open('Log');
+  await logView.expectOpen();
+  await expect(logView.logs()).toHaveCount(0);
+
+  await startLogProcess(neo);
+  await neo.navigation.open('Log');
+  await logView.expectOpen();
+  await expect(logView.logs()).toHaveCount(3);
+  await logView.clear();
+});
+
+const startLogProcess = async (neo: Neo) => {
+  const processes = await neo.processes();
+  await processes.card('runtimeLog').click();
   const editor = new ProcessEditor(neo, 'runtimeLog');
   await editor.expectOpen('19619B9BB7B9F741-f0');
+  await neo.navigation.resetAnimation();
+  await neo.navigation.disableAnimation();
   const start = editor.elementByPid('19619B9BB7B9F741-f0');
   await start.triggerQuickAction(/Start Process/);
   const end = editor.elementByPid('19619B9BB7B9F741-f1');
   await end.expectExecuted();
-  return { neo, editor };
 };
-
-test('should render table and rows correctly', async ({ page }) => {
-  const { neo } = await startLogProcess(page);
-  await neo.navigation.open('Log');
-  const logView = page.locator('.runtime-log');
-  await expect(logView).toBeVisible();
-  const rows = logView.locator('table tbody tr');
-  await expect(rows).toHaveCount(3);
-
-  await logView.getByRole('button', { name: 'Menu' }).click();
-  await page.getByRole('menu').getByRole('menuitem', { name: 'Delete All' }).click();
-  await expect(rows).toHaveCount(0);
-});

--- a/playwright/tests/page-objects/runtimelog-view.ts
+++ b/playwright/tests/page-objects/runtimelog-view.ts
@@ -1,0 +1,24 @@
+import { expect, type Locator } from '@playwright/test';
+import type { Neo } from './neo';
+
+export class RuntimeLogView {
+  readonly view: Locator;
+
+  constructor(readonly neo: Neo) {
+    this.view = neo.page.locator('.runtime-log');
+  }
+
+  async expectOpen() {
+    await expect(this.view).toBeVisible();
+  }
+
+  async clear() {
+    await this.view.getByRole('button', { name: 'Menu' }).click();
+    await this.neo.page.getByRole('menu').getByRole('menuitem', { name: 'Delete All' }).click();
+    await expect(this.logs()).toHaveCount(0);
+  }
+
+  logs() {
+    return this.view.locator('table tbody tr');
+  }
+}


### PR DESCRIPTION
Currently it always fails the first time, because the log view needs to be opened once, otherwise the logger will not be attached