### PR TITLE
Fix panel state sync

### DIFF
--- a/app/neo/browser/WebBrowser.tsx
+++ b/app/neo/browser/WebBrowser.tsx
@@ -20,11 +20,8 @@ export const WebBrowser = ({ firstWebbrowserElement }: { firstWebbrowserElement?
   const { nav, homeUrl, browser } = useWebBrowser();
   useUpdateTheme(nav.frameRef, updateFrameTheme);
   useHotkeyDispatcher(nav.frameRef);
-
-  const tabIndex = browser.openState ? 0 : -1;
-
   return (
-    <Flex direction='column' gap={1} style={{ height: '100%' }}>
+    <Flex direction='column' gap={1} style={{ height: '100%', display: browser.openState ? undefined : 'none' }}>
       <Flex
         direction='row'
         alignItems='center'
@@ -41,36 +38,11 @@ export const WebBrowser = ({ firstWebbrowserElement }: { firstWebbrowserElement?
             onClick={nav.back}
             aria-label={t('browser.goBack')}
             ref={firstWebbrowserElement}
-            tabIndex={tabIndex}
           />
-          <Button
-            icon={IvyIcons.ArrowRight}
-            title={t('browser.goForward')}
-            onClick={nav.forward}
-            aria-label={t('browser.goForward')}
-            tabIndex={tabIndex}
-          />
-          <Button
-            icon={IvyIcons.Redo}
-            title={t('browser.reloadPage')}
-            onClick={nav.reload}
-            aria-label={t('browser.reloadPage')}
-            tabIndex={tabIndex}
-          />
-          <Button
-            icon={IvyIcons.Home}
-            title={t('browser.goHome')}
-            onClick={nav.home}
-            aria-label={t('browser.goHome')}
-            tabIndex={tabIndex}
-          />
-          <Button
-            icon={IvyIcons.ExitEnd}
-            title={t('browser.openNewTab')}
-            onClick={nav.openExternal}
-            aria-label={t('browser.openNewTab')}
-            tabIndex={tabIndex}
-          />
+          <Button icon={IvyIcons.ArrowRight} title={t('browser.goForward')} onClick={nav.forward} aria-label={t('browser.goForward')} />
+          <Button icon={IvyIcons.Redo} title={t('browser.reloadPage')} onClick={nav.reload} aria-label={t('browser.reloadPage')} />
+          <Button icon={IvyIcons.Home} title={t('browser.goHome')} onClick={nav.home} aria-label={t('browser.goHome')} />
+          <Button icon={IvyIcons.ExitEnd} title={t('browser.openNewTab')} onClick={nav.openExternal} aria-label={t('browser.openNewTab')} />
         </Flex>
       </Flex>
       <iframe
@@ -79,7 +51,6 @@ export const WebBrowser = ({ firstWebbrowserElement }: { firstWebbrowserElement?
         title={t('browser.devBrowser')}
         style={{ width: '100%', height: '100%', border: 'none' }}
         loading='lazy'
-        tabIndex={tabIndex}
       />
     </Flex>
   );

--- a/app/neo/browser/useWebBrowser.tsx
+++ b/app/neo/browser/useWebBrowser.tsx
@@ -1,5 +1,5 @@
 import type { ImperativePanelHandle } from '@axonivy/ui-components';
-import { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { createContext, useContext, useMemo, useRef, useState } from 'react';
 import { useWorkspace } from '~/data/workspace-api';
 
 type WebBrowserProviderState = {
@@ -34,24 +34,19 @@ export const useWebBrowser = () => {
   if (context === undefined) throw new Error('useWebBrowser must be used within a WebBrowserProvider');
   const { panelRef, frameRef, openUrl } = context;
   const [open, setOpen] = context.openState;
-  useEffect(() => {
-    setOpen(panelRef.current?.isExpanded() ?? false);
-  }, [panelRef, setOpen]);
   const browser = {
     openState: open,
+    setOpenState: setOpen,
     panelRef,
     toggle: () => {
       if (panelRef.current?.isCollapsed()) {
         panelRef.current?.expand(40);
-        setOpen(true);
       } else {
         panelRef.current?.collapse();
-        setOpen(false);
       }
     },
     open: (url?: string) => {
       panelRef.current?.expand(40);
-      setOpen(true);
       if (url) {
         openUrl(url);
       }
@@ -62,10 +57,8 @@ export const useWebBrowser = () => {
         const nextBrowserSize = browserSizes.find(size => size > currentSize);
         if (nextBrowserSize === undefined) {
           panelRef.current.collapse();
-          setOpen(false);
         } else if (nextBrowserSize) {
           panelRef.current.resize(nextBrowserSize);
-          setOpen(true);
         }
       }
     }

--- a/app/neo/views/Views.tsx
+++ b/app/neo/views/Views.tsx
@@ -21,9 +21,10 @@ const views = [
 export type ViewIds = (typeof views)[number]['id'];
 
 export const useViews = () => {
-  const [view, setView] = useState<ViewIds | ''>('');
+  const [view, setView] = useState<ViewIds | ''>(views[0].id);
+  const [viewsCollapsed, setViewsCollapsed] = useState(true);
   const viewsRef = useRef<ImperativePanelHandle>(null);
-  return { viewsRef, view, setView };
+  return { viewsRef, view, setView, viewsCollapsed, setViewsCollapsed };
 };
 
 export const ViewTabs = ({ viewsRef, view, setView }: ReturnType<typeof useViews>) => {

--- a/app/routes/workspace-layout.tsx
+++ b/app/routes/workspace-layout.tsx
@@ -80,19 +80,35 @@ export default function Index() {
                 <ResizableHandle>
                   <ViewTabs {...views} />
                 </ResizableHandle>
-                <ResizablePanel ref={views.viewsRef} id='Views' collapsible defaultSize={0} maxSize={50} minSize={10}>
-                  <ViewContent />
+                <ResizablePanel
+                  ref={views.viewsRef}
+                  onCollapse={() => views.setViewsCollapsed(false)}
+                  onExpand={() => views.setViewsCollapsed(true)}
+                  id='Views'
+                  collapsible
+                  defaultSize={0}
+                  maxSize={50}
+                  minSize={10}
+                  style={{ overflow: 'auto' }}
+                >
+                  {views.viewsCollapsed && <ViewContent />}
                 </ResizablePanel>
               </ResizablePanelGroup>
             </Tabs>
           </Flex>
         </ResizablePanel>
 
-        <ResizableHandle
-          className='browser-resize-handle'
-          style={{ width: 3, height: 'calc(100% - 42px)', backgroundColor: 'var(--N200)' }}
-        />
-        <ResizablePanel ref={browser.panelRef} id='Browser' collapsible defaultSize={0} maxSize={70} minSize={10}>
+        <ResizableHandle className='browser-resize-handle' style={{ width: 3, height: 'calc(100% - 42px)' }} />
+        <ResizablePanel
+          ref={browser.panelRef}
+          onCollapse={() => browser.setOpenState(false)}
+          onExpand={() => browser.setOpenState(true)}
+          id='Browser'
+          collapsible
+          defaultSize={0}
+          maxSize={70}
+          minSize={10}
+        >
           <WebBrowser firstWebbrowserElement={firstWebbrowserElement} />
         </ResizablePanel>
       </ResizablePanelGroup>


### PR DESCRIPTION
- Fix simulation switch state, if browser panel is closed by resizing
- Fix tabbing into view panel when closed moves view
- Simplify disable tabbing into browser when closed