### PR TITLE
remove ivy.enable.lsp option

### DIFF
--- a/playwright/neo-test-project/pom.xml
+++ b/playwright/neo-test-project/pom.xml
@@ -57,7 +57,7 @@
           <deployToEngineApplication>${engine.test.app}</deployToEngineApplication>
           <engineDirectory>${engine.dir}</engineDirectory>
           <additionalVmOptions>
-            -Divy.enable.lsp=true -Ddev.mode=true
+            -Ddev.mode=true
           </additionalVmOptions>
         </configuration>
         <executions>


### PR DESCRIPTION
as far as I know, this property does not exist anymore.