### PR TITLE
fix data-class-graph-test

### DIFF
--- a/playwright/tests/integration/data-classes.spec.ts
+++ b/playwright/tests/integration/data-classes.spec.ts
@@ -62,7 +62,6 @@ test('data classes graph', async ({ page }) => {
   await overview.viewToggle.getByRole('radio', { name: 'Graph View' }).click();
   const graph = overview.graph;
   await expect(graph.edges).toHaveCount(2);
-  await expect(graph.nodes).toHaveCount(9);
   const quickStartNode = graph.getNodeByText('QuickStartTutorial');
   await expect(quickStartNode.detailSeperator).toBeHidden();
   await quickStartNode.expandNode.click();


### PR DESCRIPTION
I need to remove the node-count-check, because of temp dataclasses i can't control:
![grafik](https://github.com/user-attachments/assets/ed620e91-f312-4977-82f2-0394275653bc)
