### PR TITLE
Fix theme shortcut not working on ws overview

### DIFF
--- a/app/neo/Navigation.tsx
+++ b/app/neo/Navigation.tsx
@@ -1,32 +1,27 @@
-import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, Flex, useHotkeys } from '@axonivy/ui-components';
+import { Button, Flex, useHotkeys } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useRef } from 'react';
-import { useTranslation } from 'react-i18next';
 import { NavLink, useNavigate } from 'react-router';
-import { LanguageSelector } from '~/neo/settings/LanguageSelector';
+import { LanguageSettings } from '~/neo/settings/LanguageSettings';
 import { useKnownHotkeys } from '~/utils/hotkeys';
 import { useNeoClient } from './client/useNeoClient';
-import { AnimationSettingsMenu } from './settings/AnimationSettingsMenu';
-import { ThemeSettings, useCycleTheme } from './settings/ThemeSettings';
+import { AnimationSettings } from './settings/AnimationSettings';
+import { Settings } from './settings/Settings';
+import { ThemeSettings } from './settings/ThemeSettings';
 import { useCycleAnimationSettings } from './settings/useSettings';
 
 export const Navigation = () => {
   useNeoClient();
-  const { t } = useTranslation();
   const { cycleAnimationMode, cycleAnimationSpeed, toggleAnimation, resetEngine } = useCycleAnimationSettings();
   const navigate = useNavigate();
-  const cycleTheme = useCycleTheme();
-
   const hotkeys = useKnownHotkeys();
   const workspacesElement = useRef<HTMLButtonElement>(null);
-
   useHotkeys(hotkeys.focusNav.hotkey, () => workspacesElement.current?.focus(), { enableOnFormTags: true });
   useHotkeys(hotkeys.openWorkspaces.hotkey, () => navigate(''), { enableOnFormTags: true });
   useHotkeys(hotkeys.openProcesses.hotkey, () => navigate('processes'), { enableOnFormTags: true });
   useHotkeys(hotkeys.openForms.hotkey, () => navigate('forms'), { enableOnFormTags: true });
   useHotkeys(hotkeys.openDataClasses.hotkey, () => navigate('dataclasses'), { enableOnFormTags: true });
   useHotkeys(hotkeys.openConfigs.hotkey, () => navigate('configurations'), { enableOnFormTags: true });
-  useHotkeys(hotkeys.changeTheme.hotkey, cycleTheme);
   useHotkeys(hotkeys.toggleAnimation.hotkey, toggleAnimation);
   useHotkeys(hotkeys.animationSpeed.hotkey, cycleAnimationSpeed);
   useHotkeys(hotkeys.animationMode.hotkey, cycleAnimationMode);
@@ -93,16 +88,11 @@ export const Navigation = () => {
           {({ isActive }) => <Button icon={IvyIcons.Tool} size='large' toggle={isActive} />}
         </NavLink>
       </Flex>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button icon={IvyIcons.Settings} size='large' aria-label={t('common.label.settings')} title={t('common.label.settings')} />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent side='right'>
-          <AnimationSettingsMenu />
-          <LanguageSelector />
-          <ThemeSettings />
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <Settings side='right'>
+        <AnimationSettings />
+        <LanguageSettings />
+        <ThemeSettings />
+      </Settings>
     </Flex>
   );
 };

--- a/app/neo/settings/AnimationSettings.tsx
+++ b/app/neo/settings/AnimationSettings.tsx
@@ -18,7 +18,7 @@ import { useStopBpmEngine } from '~/data/project-api';
 import { useKnownHotkeys } from '~/utils/hotkeys';
 import { speedModes, useSettings, type AnimationFollowMode } from './useSettings';
 
-export const AnimationSettingsMenu = () => {
+export const AnimationSettings = () => {
   const { t } = useTranslation();
   const { animation, enableAnimation, animationSpeed, animationMode } = useSettings();
   const { stopBpmEngine } = useStopBpmEngine();

--- a/app/neo/settings/LanguageSettings.tsx
+++ b/app/neo/settings/LanguageSettings.tsx
@@ -11,7 +11,7 @@ import { IvyIcons } from '@axonivy/ui-icons';
 import i18next from 'i18next';
 import { useTranslation } from 'react-i18next';
 
-export const LanguageSelector = () => {
+export const LanguageSettings = () => {
   const { t } = useTranslation();
   const languages = Object.keys(i18next.services.resourceStore.data);
   return (

--- a/app/neo/settings/Settings.tsx
+++ b/app/neo/settings/Settings.tsx
@@ -1,0 +1,22 @@
+import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, useHotkeys } from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
+import type { ComponentProps } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useKnownHotkeys } from '~/utils/hotkeys';
+import { useCycleTheme } from './ThemeSettings';
+
+export const Settings = (props: ComponentProps<typeof DropdownMenuContent>) => {
+  const { t } = useTranslation();
+  const cycleTheme = useCycleTheme();
+  const { changeTheme } = useKnownHotkeys();
+  useHotkeys(changeTheme.hotkey, cycleTheme);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button icon={IvyIcons.Settings} size='large' aria-label={t('common.label.settings')} title={t('common.label.settings')} />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side='bottom' {...props} />
+    </DropdownMenu>
+  );
+};

--- a/app/routes/workspaces/overview.tsx
+++ b/app/routes/workspaces/overview.tsx
@@ -7,9 +7,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
   Flex,
   Input
 } from '@axonivy/ui-components';
@@ -26,7 +23,8 @@ import { useArtifactValidation } from '~/neo/artifact/validation';
 import { ControlBar } from '~/neo/control-bar/ControlBar';
 import { InfoPopover } from '~/neo/InfoPopover';
 import { Overview } from '~/neo/Overview';
-import { LanguageSelector } from '~/neo/settings/LanguageSelector';
+import { LanguageSettings } from '~/neo/settings/LanguageSettings';
+import { Settings } from '~/neo/settings/Settings';
 import { ThemeSettings } from '~/neo/settings/ThemeSettings';
 import { useSearch } from '~/neo/useSearch';
 import { useDownloadWorkspace } from '~/neo/workspace/useDownloadWorkspace';
@@ -51,15 +49,10 @@ export default function Index() {
     <>
       <ControlBar>
         <Flex alignItems='center' gap={1} style={{ paddingInline: 'var(--size-2)', marginInlineStart: 'auto', flex: '0 0 auto' }}>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button icon={IvyIcons.Settings} size='large' aria-label={t('common.label.settings')} title={t('common.label.settings')} />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent side='bottom'>
-              <LanguageSelector />
-              <ThemeSettings />
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <Settings side='bottom'>
+            <LanguageSettings />
+            <ThemeSettings />
+          </Settings>
         </Flex>
       </ControlBar>
       <div style={{ height: 'calc(100vh - 41px)' }}>


### PR DESCRIPTION
Shift+T changes the theme if your on a workspace. The setting also exists on the workspaces overview.
However the shortcut was only bound on the Navigation component which was not used on the workspaces overview.