### PR TITLE
XIVY-17303 Breadcrumb project switch menu

### DIFF
--- a/app/neo/Breadcrumb.tsx
+++ b/app/neo/Breadcrumb.tsx
@@ -1,39 +1,80 @@
-import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@axonivy/ui-components';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  Flex
+} from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
+import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink, useParams } from 'react-router';
 import { Fragment } from 'react/jsx-runtime';
 
+type BreadcrumbItem = { name: string; href?: string; menu?: ReactNode };
+
 type BreadcrumbProps = {
   style?: React.CSSProperties;
-  items?: Array<{ name: string; href?: string }>;
+  items?: Array<BreadcrumbItem>;
 };
 
 export const Breadcrumbs = ({ style, items = [] }: BreadcrumbProps) => {
   const { t } = useTranslation();
   const { ws } = useParams();
-  const workspacesItem = { name: t('neo.workspaces'), href: '' };
-  const wsItem = { name: ws, href: ws };
+  const workspacesItem: BreadcrumbItem = { name: t('neo.workspaces'), href: '' };
+  const wsItem: BreadcrumbItem = { name: ws ?? '', href: ws };
   const breadcrumbItems = [workspacesItem, wsItem, ...items];
   const lastItem = breadcrumbItems.pop();
   return (
     <Breadcrumb style={style ?? { fontSize: 12 }}>
       <BreadcrumbList>
-        {breadcrumbItems?.map(({ name, href }) => (
-          <Fragment key={`${name}-${href}`}>
+        {breadcrumbItems?.map(item => (
+          <Fragment key={`${item.name}-${item.href}`}>
             <BreadcrumbItem>
-              {href !== undefined ? (
-                <BreadcrumbLink asChild>
-                  <NavLink to={`/${href ?? ''}`}>{name}</NavLink>
-                </BreadcrumbLink>
-              ) : (
-                name
-              )}
+              <BreadcrumbPart {...item} />
             </BreadcrumbItem>
             <BreadcrumbSeparator />
           </Fragment>
         ))}
-        <BreadcrumbPage>{lastItem?.name}</BreadcrumbPage>
+        {lastItem && (
+          <BreadcrumbItem>
+            <BreadcrumbPage>
+              <BreadcrumbPart {...lastItem} />
+            </BreadcrumbPage>
+          </BreadcrumbItem>
+        )}
       </BreadcrumbList>
     </Breadcrumb>
   );
+};
+
+const BreadcrumbPart = ({ name, href, menu }: BreadcrumbItem) => {
+  let item: ReactNode = name;
+  if (href !== undefined) {
+    item = (
+      <BreadcrumbLink asChild>
+        <NavLink to={`/${href ?? ''}`}>{name}</NavLink>
+      </BreadcrumbLink>
+    );
+  }
+  if (menu) {
+    return (
+      <Flex direction='row' alignItems='center' gap={1}>
+        {item}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button icon={IvyIcons.Chevron} rotate={90} style={{ height: 16 }} />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>{menu}</DropdownMenuContent>
+        </DropdownMenu>
+      </Flex>
+    );
+  }
+  return item;
 };

--- a/app/neo/editors/MountedEditor.tsx
+++ b/app/neo/editors/MountedEditor.tsx
@@ -8,7 +8,6 @@ import type { Editor, EditorType } from './editor';
 const HotkeysEditor = ({ id, type, name, children }: Editor & { children: React.ReactNode }) => {
   const { pathname } = useLocation();
   const [mounted, setMounted] = useState(false);
-  const { pmv } = useParams();
   const overviewBreadcrumbItem = useOverviewBreadcrumbItem(type);
   useEffect(() => {
     if (pathname === id) {
@@ -26,7 +25,7 @@ const HotkeysEditor = ({ id, type, name, children }: Editor & { children: React.
       style={{ height: '100%', display: pathname !== id ? 'none' : undefined }}
     >
       <Breadcrumbs
-        items={[overviewBreadcrumbItem, { name: pmv ?? '' }, { name }]}
+        items={[...overviewBreadcrumbItem, { name }]}
         style={{ borderBottom: 'var(--basic-border)', padding: '4px var(--size-3)' }}
       />
       {children}
@@ -49,18 +48,32 @@ export const MountedEditor = (props: Editor & { children: React.ReactNode }) => 
 };
 
 const useOverviewBreadcrumbItem = (type: EditorType) => {
+  const { ws, pmv } = useParams();
+  const name = useTypeName(type);
+  const href = `${ws}/${typeToPath(type)}`;
+  const pmvItem = pmv ? { name: pmv, href: `${href}?p=${pmv}` } : { name: '' };
+  return [{ name, href }, pmvItem];
+};
+
+const useTypeName = (type: EditorType) => {
   const { t } = useTranslation();
-  const { ws } = useParams();
   switch (type) {
     case 'processes':
-      return { name: t('neo.processes'), href: `${ws}/${type}` };
+      return t('neo.processes');
     case 'forms':
-      return { name: t('neo.forms'), href: `${ws}/${type}` };
+      return t('neo.forms');
     case 'cms':
     case 'variables':
     case 'configurations':
-      return { name: t('neo.configs'), href: `${ws}/configurations` };
+      return t('neo.configs');
     case 'dataclasses':
-      return { name: t('neo.dataClasses'), href: `${ws}/${type}` };
+      return t('neo.dataClasses');
   }
+};
+
+const typeToPath = (type: EditorType) => {
+  if (type === 'cms' || type === 'variables') {
+    return 'configurations';
+  }
+  return type;
 };

--- a/app/routes/projects/DependencyDialog.tsx
+++ b/app/routes/projects/DependencyDialog.tsx
@@ -1,0 +1,57 @@
+import { BasicDialogContent, Button, Dialog, DialogContent, useDialogHotkeys } from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAddDependencyReq } from '~/data/dependency-api';
+import type { ProjectBean } from '~/data/generated/ivy-client';
+import type { ProjectIdentifier } from '~/data/project-api';
+import { ProjectSelect } from '~/neo/artifact/ProjectSelect';
+import { CreateNewArtefactButton } from '~/neo/overview/Overview';
+
+export const AddDependencyDialog = ({ project }: { project: ProjectIdentifier }) => {
+  const { t } = useTranslation();
+  const { open, onOpenChange } = useDialogHotkeys(['addDependencyDialog']);
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <CreateNewArtefactButton title={t('projects.addDependency')} onClick={() => onOpenChange(true)} />
+      <DialogContent>
+        <AddDependencyDialogContent project={project} />
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const AddDependencyDialogContent = ({ project }: { project: ProjectIdentifier }) => {
+  const { t } = useTranslation();
+  const [dependency, setDependency] = useState<ProjectBean>();
+  const { addDependency } = useAddDependencyReq();
+  return (
+    <BasicDialogContent
+      title={t('projects.addDependencyTo', { project: project.pmv })}
+      description={t('projects.addDependencyDescription')}
+      cancel={
+        <Button variant='outline' size='large'>
+          {t('common.label.cancel')}
+        </Button>
+      }
+      submit={
+        <Button
+          variant='primary'
+          size='large'
+          disabled={dependency === undefined}
+          onClick={() => addDependency(project, dependency?.id)}
+          icon={IvyIcons.Plus}
+        >
+          {t('common.label.add')}
+        </Button>
+      }
+    >
+      <ProjectSelect
+        setProject={setDependency}
+        setDefaultValue={true}
+        projectFilter={p => p.id.pmv !== project.pmv}
+        label={t('projects.selectDependency')}
+      />
+    </BasicDialogContent>
+  );
+};

--- a/app/routes/projects/overview.tsx
+++ b/app/routes/projects/overview.tsx
@@ -1,34 +1,24 @@
-import {
-  BasicDialogContent,
-  Button,
-  Dialog,
-  DialogContent,
-  Flex,
-  Separator,
-  Spinner,
-  useDialogHotkeys,
-  vars
-} from '@axonivy/ui-components';
+import { DropdownMenuItem, Flex, Separator, Spinner, vars } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
-import { useMemo, useState, type ReactNode } from 'react';
+import { useMemo, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { MetaFunction } from 'react-router';
 import { useNavigate, useParams } from 'react-router';
 import { NEO_DESIGNER } from '~/constants';
-import { useAddDependencyReq, useDependencies, useRemoveDependency } from '~/data/dependency-api';
+import { useDependencies, useRemoveDependency } from '~/data/dependency-api';
 import type { ProjectBean } from '~/data/generated/ivy-client';
 import { useSortedProjects, type ProjectIdentifier } from '~/data/project-api';
-import { ProjectSelect } from '~/neo/artifact/ProjectSelect';
 import { Breadcrumbs } from '~/neo/Breadcrumb';
 import { ArtifactCard } from '~/neo/overview/artifact/ArtifactCard';
 import { ArtifactCardMenu } from '~/neo/overview/artifact/ArtifactCardMenu';
 import { useDeleteConfirmDialog } from '~/neo/overview/artifact/DeleteConfirmDialog';
 import { PreviewSvg } from '~/neo/overview/artifact/PreviewSvg';
-import { CreateNewArtefactButton, Overview } from '~/neo/overview/Overview';
+import { Overview } from '~/neo/overview/Overview';
 import { OverviewContent } from '~/neo/overview/OverviewContent';
 import { OverviewFilter, useOverviewFilter } from '~/neo/overview/OverviewFilter';
 import { OverviewInfoCard } from '~/neo/overview/OverviewInfoCard';
 import { OverviewTitle } from '~/neo/overview/OverviewTitle';
+import { AddDependencyDialog } from './DependencyDialog';
 
 export const meta: MetaFunction = ({ params }) => {
   return [
@@ -59,7 +49,7 @@ export default function Index() {
 
   return (
     <Overview>
-      <Breadcrumbs items={[{ name: t('neo.projects') }, { name: project.id.pmv }]} />
+      <Breadcrumbs items={[{ name: t('neo.projects') }, { name: project.id.pmv, menu: <BreadcrumbProjectSwitcher project={project} /> }]} />
       <OverviewTitle title={t('projects.details', { project: project.id.pmv })} />
       <Flex
         direction='row'
@@ -169,50 +159,16 @@ const useDepsTags = (dependency: ProjectIdentifier) => {
   return tags;
 };
 
-const AddDependencyDialog = ({ project }: { project: ProjectIdentifier }) => {
-  const { t } = useTranslation();
-  const { open, onOpenChange } = useDialogHotkeys(['addDependencyDialog']);
+const BreadcrumbProjectSwitcher = ({ project }: { project: ProjectBean }) => {
+  const projects = useSortedProjects().data?.filter(p => p.id !== project.id);
+  const nav = useNavigate();
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <CreateNewArtefactButton title={t('projects.addDependency')} onClick={() => onOpenChange(true)} />
-      <DialogContent>
-        <AddDependencyDialogContent project={project} />
-      </DialogContent>
-    </Dialog>
-  );
-};
-
-const AddDependencyDialogContent = ({ project }: { project: ProjectIdentifier }) => {
-  const { t } = useTranslation();
-  const [dependency, setDependency] = useState<ProjectBean>();
-  const { addDependency } = useAddDependencyReq();
-  return (
-    <BasicDialogContent
-      title={t('projects.addDependencyTo', { project: project.pmv })}
-      description={t('projects.addDependencyDescription')}
-      cancel={
-        <Button variant='outline' size='large'>
-          {t('common.label.cancel')}
-        </Button>
-      }
-      submit={
-        <Button
-          variant='primary'
-          size='large'
-          disabled={dependency === undefined}
-          onClick={() => addDependency(project, dependency?.id)}
-          icon={IvyIcons.Plus}
-        >
-          {t('common.label.add')}
-        </Button>
-      }
-    >
-      <ProjectSelect
-        setProject={setDependency}
-        setDefaultValue={true}
-        projectFilter={p => p.id.pmv !== project.pmv}
-        label={t('projects.selectDependency')}
-      />
-    </BasicDialogContent>
+    <>
+      {projects?.map(project => (
+        <DropdownMenuItem key={project.id.pmv} onClick={() => nav(`../${project.id.pmv}`, { relative: 'path' })}>
+          {project.id.pmv}
+        </DropdownMenuItem>
+      ))}
+    </>
   );
 };

--- a/playwright/tests/integration/breadcrumbs.spec.ts
+++ b/playwright/tests/integration/breadcrumbs.spec.ts
@@ -2,23 +2,49 @@ import test, { expect } from '@playwright/test';
 import { DataClassEditor } from '../page-objects/data-class-editor';
 import { Neo } from '../page-objects/neo';
 import { Overview } from '../page-objects/overview';
-import { APP, TEST_PROJECT } from './constants';
+import { APP, TEST_PROJECT, WORKSPACE } from './constants';
 
-test('navigate via breadcrumbs', async ({ page }) => {
+test('editor breadcrumbs', async ({ page }) => {
   const neo = await Neo.openWorkspace(page, `dataclasses/${APP}/${TEST_PROJECT}/dataclasses/neo/test/project/QuickStartTutorial`);
   const editor = new DataClassEditor(neo, 'QuickStartTutorial');
   await editor.expectOpen('product');
-  await neo.breadcrumbs.expectItems(['Workspaces', 'neo-test-project', 'Data Classes', 'neo-test-project', 'QuickStartTutorial']);
+  await neo.breadcrumbs.expectItems(['Workspaces', WORKSPACE, 'Data Classes', TEST_PROJECT, 'QuickStartTutorial']);
 
-  await neo.breadcrumbs.item('Data Classes').click();
+  await neo.breadcrumbs.item(TEST_PROJECT).last().click();
   const overview = new Overview(page);
   await expect(overview.title).toHaveText('Data Classes');
-  await neo.breadcrumbs.expectItems(['Workspaces', 'neo-test-project', 'Data Classes']);
+  await expect(overview.filter.filterTag(TEST_PROJECT)).toBeVisible();
+  await neo.breadcrumbs.expectItems(['Workspaces', WORKSPACE, 'Data Classes']);
+  await page.goBack();
 
-  await neo.breadcrumbs.item('neo-test-project').click();
+  await neo.breadcrumbs.item('Data Classes').click();
+  await expect(overview.title).toHaveText('Data Classes');
+  await expect(overview.filter.filterTag(TEST_PROJECT)).toBeHidden();
+  await neo.breadcrumbs.expectItems(['Workspaces', WORKSPACE, 'Data Classes']);
+
+  await neo.breadcrumbs.item(WORKSPACE).click();
   await expect(overview.title).toHaveText('Projects');
 
   await neo.breadcrumbs.item('Workspaces').click();
   await expect(overview.title).toHaveText('Manage your workspaces');
   await expect(neo.breadcrumbs.navigation).toBeHidden();
+});
+
+test('project breadcrumbs', async ({ page }) => {
+  const neo = await Neo.openWorkspace(page, `projects/${APP}/${TEST_PROJECT}`);
+  const overview = new Overview(page);
+  await expect(overview.infoTitle).toHaveText(`Project details: ${TEST_PROJECT}`);
+  await neo.breadcrumbs.expectItems(['Workspaces', WORKSPACE, 'Projects', TEST_PROJECT]);
+
+  await neo.breadcrumbs.item(TEST_PROJECT).last().getByRole('button').focus();
+  await page.keyboard.press('Enter');
+  await expect(page.getByRole('menu')).toBeVisible();
+  // Fixme after create project is supported
+
+  // const otherProject = page.getByRole('menu').getByRole('menuitem', { name: 'quick-start-tutorial' });
+  // await expect(otherProject).toBeVisible();
+  // await otherProject.click();
+
+  // await expect(overview.infoTitle).toHaveText(`Project details: quick-start-tutorial`);
+  // await neo.breadcrumbs.expectItems(['Workspaces', WORKSPACE, 'Projects', 'quick-start-tutorial']);
 });

--- a/playwright/tests/integration/configs.spec.ts
+++ b/playwright/tests/integration/configs.spec.ts
@@ -26,7 +26,7 @@ test('search configs', async ({ page }) => {
   await expect(overview.cards).toHaveCount(1);
 });
 
-test('filter processes', async ({ page }) => {
+test('filter configs', async ({ page }) => {
   await Neo.openWorkspace(page, 'configurations?p=not-existing');
   const overview = new Overview(page);
   await expect(overview.filter.filterTag('not-existing')).toBeVisible();

--- a/playwright/tests/integration/data-classes.spec.ts
+++ b/playwright/tests/integration/data-classes.spec.ts
@@ -49,7 +49,7 @@ test('search data classes', async ({ page }) => {
   await expect(overview.cards).toHaveCount(1);
 });
 
-test('filter processes', async ({ page }) => {
+test('filter data classes', async ({ page }) => {
   await Neo.openWorkspace(page, 'dataclasses?p=not-existing');
   const overview = new Overview(page);
   await expect(overview.filter.filterTag('not-existing')).toBeVisible();

--- a/playwright/tests/integration/forms.spec.ts
+++ b/playwright/tests/integration/forms.spec.ts
@@ -43,7 +43,7 @@ test('search forms', async ({ page }) => {
   await expect(overview.cards).toHaveCount(1);
 });
 
-test('filter processes', async ({ page }) => {
+test('filter forms', async ({ page }) => {
   await Neo.openWorkspace(page, 'forms?p=not-existing');
   const overview = new Overview(page);
   await expect(overview.filter.filterTag('not-existing')).toBeVisible();

--- a/playwright/tests/page-objects/breadcrumbs.ts
+++ b/playwright/tests/page-objects/breadcrumbs.ts
@@ -13,14 +13,13 @@ export class Breadcrumbs {
   }
 
   item(name: string) {
-    return this.items.getByRole('link', { name });
+    return this.navigation.locator('.ui-breadcrumb-item', { hasText: name });
   }
 
   async expectItems(items: string[]) {
-    await expect(this.items).toHaveCount(items.length - 1);
-    for (let i = 0; i < items.length - 1; i++) {
+    await expect(this.items).toHaveCount(items.length);
+    for (let i = 0; i < items.length; i++) {
       await expect(this.items.nth(i)).toHaveText(items[i]);
     }
-    await expect(this.navigation.locator('.ui-breadcrumb-page')).toHaveText(items.at(-1)!);
   }
 }


### PR DESCRIPTION
- Move DependencyDialog to own file
- Support editor breadcrumbs to click on project -> will open processes, dataclasses etc with filter on project
- Support menus in breadcrumbs
- Add breadcrumb menu to switch projects on project detail page

<img width="1040" height="534" alt="Screenshot 2025-08-08 at 15 24 16" src="https://github.com/user-attachments/assets/bad0b03c-4565-4e43-b803-d3ab1f697f9b" />
