### PR TITLE
Fix ide lint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,6 @@
     "source.organizeImports": "always"
   },
   "editor.insertSpaces": true,
-  "eslint.validate": ["javascript", "typescript"],
   "search.exclude": {
     "**/node_modules": true,
     "**/lib": true

--- a/neo.code-workspace
+++ b/neo.code-workspace
@@ -32,7 +32,6 @@
       "source.organizeImports": "always"
     },
     "editor.insertSpaces": true,
-    "eslint.validate": ["javascript", "typescript"],
     "search.exclude": {
       "**/node_modules": true,
       "**/lib": true


### PR DESCRIPTION
The vscode eslint plugin did made a change in the latest version (3.0.16) which change the default validation languages. So define this setting will no longer merge it with some default languages but fix them. 
So either we would need to define also "typescriptreact" to get lint warnings in tsx files
Or we can remove this setting completely and do the extension it's job (which also seems to work)

This has no effect on the build, there lint problems are reported as always, but have this stuff in the editor improves the DX :)