### PR TITLE
XIVY-17303 Restyle filter tags

### DIFF
--- a/app/neo/overview/OverviewFilterTags.tsx
+++ b/app/neo/overview/OverviewFilterTags.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, Flex, IvyIcon } from '@axonivy/ui-components';
+import { Button, Flex, IvyIcon } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import type React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -24,9 +24,9 @@ export const OverviewFilterTags = ({ viewType, projects, setProjects, tags, setT
         <Tag
           key={project}
           name={
-            <Badge variant='outline'>
+            <>
               <IvyIcon icon={IvyIcons.Folders} /> {project}
-            </Badge>
+            </>
           }
           remove={() => setProjects(projects.filter(p => p !== project))}
         />
@@ -35,9 +35,9 @@ export const OverviewFilterTags = ({ viewType, projects, setProjects, tags, setT
         <Tag
           key={tag}
           name={
-            <Badge variant='outline'>
+            <>
               <IvyIcon icon={IvyIcons.Label} /> {tag}
-            </Badge>
+            </>
           }
           remove={() => setTags(tags.filter(t => t !== tag))}
         />


### PR DESCRIPTION
<img width="412" height="306" alt="image" src="https://github.com/user-attachments/assets/55a2c21b-d500-4b90-8312-3e29cfd0d823" />

instead of
<img width="430" height="332" alt="image" src="https://github.com/user-attachments/assets/25d39677-b871-4c26-b6b7-cbab59eec758" />

Any reason why you did this @ivy-jh? Looks a little bit weird to me. 
I mean yes on the mock the tags are rendered as badges also here in the filters but not the projects right?
I thought instead of the colored badges we do now the icon thing. 
Or we should maybe do later the colored badges.
But this outline badges inside the tags (border in border) looks a little bit weird to me. Or what do you think?