### PR TITLE
chore: npm audit fix transient CVEs for release/12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12850,9 +12850,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Baseline audit status: 10 CVEs
- Final audit status: 8 CVEs
- Files changed: package-lock.json
- Remaining unresolved CVEs:
  - GHSA-xxjr-mmjv-4gpg: lodash
  - GHSA-r5fr-rjxr-66jc: lodash
  - GHSA-f23m-r3pf-42rh: lodash